### PR TITLE
Add smooth subject completion animations and final particle finale

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>作业预览</title>
+<style>
+body {
+  margin: 0;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  background: linear-gradient(-45deg, #141e30, #243b55, #141e30, #243b55);
+  background-size: 400% 400%;
+  animation: flow 30s ease infinite;
+  color: #eee;
+}
+@keyframes flow {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+.container {
+  width: 90%;
+  max-width: 420px;
+  margin: 20px auto;
+}
+header {
+  background: linear-gradient(#3a3a3a, #1e1e1e);
+  border-radius: 12px;
+  border: 1px solid #555;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 2px 2px rgba(0, 0, 0, 0.3);
+  padding: 15px;
+  text-align: center;
+  font-size: 24px;
+  font-weight: 600;
+  color: #f0f0f0;
+}
+#preview {
+  background: #1e1e1e;
+  border-radius: 12px;
+  border: 1px solid #555;
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.5);
+  margin-top: 20px;
+  padding: 20px;
+  height: 400px;
+  background-image:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+  background-size: 100% 20px, 20px 100%;
+  overflow: auto;
+  color: #eee;
+}
+.subject {
+  margin-bottom: 20px;
+}
+.subject h2 {
+  margin: 0 0 10px;
+  font-size: 20px;
+}
+.task {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  width: 100%;
+}
+.task input {
+  width: 18px;
+  height: 18px;
+  margin-right: 10px;
+}
+.task span {
+  position: relative;
+  display: inline-block;
+}
+.task span::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  height: 2px;
+  background: #eee;
+  width: 0;
+  transform: translateY(-50%);
+  transition: width 0.5s ease;
+}
+.task input:checked + span::after {
+  width: 100%;
+}
+.task input:checked + span {
+  color: #777;
+}
+.subject.completed {
+  opacity: 0.6;
+}
+.subject.moving {
+  animation: slideOut 0.6s forwards;
+}
+@keyframes slideOut {
+  to {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+}
+.subject.fade-in {
+  animation: fadeIn 0.6s forwards;
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 0.6; }
+}
+#progress {
+  margin-top: 20px;
+  text-align: center;
+}
+#final-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  overflow: hidden;
+  z-index: 999;
+  pointer-events: none;
+}
+.particle {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  background: #fff;
+  border-radius: 50%;
+  animation: particle 1.5s forwards;
+}
+@keyframes particle {
+  to {
+    transform: translateY(-40px) scale(0);
+    opacity: 0;
+  }
+}
+#final-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.8);
+  font-size: 32px;
+  color: #fff;
+  opacity: 0;
+  animation: textPop 1s forwards 1.5s;
+}
+@keyframes textPop {
+  0% { opacity: 0; transform: translate(-50%, -50%) scale(0.8); }
+  50% { opacity: 1; transform: translate(-50%, -50%) scale(1.05); }
+  100% { transform: translate(-50%, -50%) scale(1); }
+}
+</style>
+</head>
+<body>
+<div class="container">
+  <header id="date"></header>
+  <div id="preview"></div>
+  <div id="progress">
+    <svg width="120" height="120">
+      <circle cx="60" cy="60" r="50" stroke="#555" stroke-width="10" fill="none" />
+      <circle id="progress-ring" cx="60" cy="60" r="50" stroke="#4caf50" stroke-width="10" fill="none" stroke-linecap="round" stroke-dasharray="314" stroke-dashoffset="314" transform="rotate(-90 60 60)" />
+      <text id="progress-text" x="60" y="60" text-anchor="middle" dominant-baseline="central" fill="#eee" font-size="20">0%</text>
+    </svg>
+  </div>
+</div>
+<div id="final-overlay" style="display:none"></div>
+<script>
+const subjects = {
+  '语文': ['背诵《春晓》', '完成练习册第10页'],
+  '数学': ['做作业本P20-22', '复习二次函数'],
+  '英语': ['背单词Unit5', '完成语法练习'],
+  '物理': ['预习第3章', '完成实验报告'],
+  '化学': ['练习化学方程式', '完成习题2-4'],
+  '生物': ['复习细胞结构', '完成小测卷'],
+  '历史': ['阅读《中国近代史》第2章', '整理课堂笔记'],
+  '政治': ['思考题第1-3题'],
+  '地理': ['完成地图册练习']
+};
+const preview = document.getElementById('preview');
+let totalTasks = 0;
+for (const [subject, works] of Object.entries(subjects)) {
+  const section = document.createElement('section');
+  section.className = 'subject';
+  const h2 = document.createElement('h2');
+  h2.textContent = subject;
+  section.appendChild(h2);
+  works.forEach(work => {
+    totalTasks++;
+    const label = document.createElement('label');
+    label.className = 'task';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    const span = document.createElement('span');
+    span.textContent = work;
+    label.appendChild(input);
+    label.appendChild(span);
+    section.appendChild(label);
+    input.addEventListener('change', () => {
+      updateProgress();
+      checkSubject(section);
+    });
+  });
+  preview.appendChild(section);
+}
+let completedTasks = 0;
+function updateProgress() {
+  completedTasks = document.querySelectorAll('#preview input:checked').length;
+  const percent = Math.round((completedTasks / totalTasks) * 100);
+  const ring = document.getElementById('progress-ring');
+  const offset = 314 * (1 - completedTasks / totalTasks);
+  ring.style.strokeDashoffset = offset;
+  document.getElementById('progress-text').textContent = percent + '%';
+}
+function checkSubject(section) {
+  const checks = section.querySelectorAll('input').length;
+  const checked = section.querySelectorAll('input:checked').length;
+  if (checks === checked && !section.classList.contains('completed')) {
+    section.classList.add('moving');
+    setTimeout(() => {
+      section.classList.remove('moving');
+      section.classList.add('completed', 'fade-in');
+      preview.appendChild(section);
+      setTimeout(() => section.classList.remove('fade-in'), 600);
+      checkAll();
+    }, 600);
+  } else if (checked < checks && section.classList.contains('completed')) {
+    section.classList.remove('completed');
+    preview.insertBefore(section, preview.querySelector('.subject:not(.completed)'));
+  }
+}
+function checkAll() {
+  const total = document.querySelectorAll('.subject').length;
+  const done = document.querySelectorAll('.subject.completed').length;
+  if (total === done) {
+    showFinal();
+  }
+}
+function showFinal() {
+  document.querySelector('.container').style.display = 'none';
+  const overlay = document.getElementById('final-overlay');
+  overlay.style.display = 'block';
+  for (let i = 0; i < 80; i++) {
+    const p = document.createElement('span');
+    p.className = 'particle';
+    p.style.left = Math.random() * 100 + '%';
+    p.style.top = Math.random() * 100 + '%';
+    overlay.appendChild(p);
+  }
+  const text = document.createElement('div');
+  text.id = 'final-text';
+  text.textContent = '今日任务完成，请求休息';
+  overlay.appendChild(text);
+}
+function updateTime() {
+  const now = new Date();
+  const fmt = new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric', month: 'long', day: 'numeric',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+    hour12: false
+  });
+  document.getElementById('date').textContent = fmt.format(now);
+}
+setInterval(updateTime, 1000);
+updateTime();
+updateProgress();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Refine dark theme with slower flowing gradient
- Strike-through matches text width and completed subjects slide to bottom
- Show full-screen particle effect and message when all tasks are done

## Testing
- `python -m http.server 8000`
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689f14e7f2e8832483f4c8f79bea2d67