### PR TITLE
Display refresh timestamp instead of live clock

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 import subjects from '../data/subjects.js';
 const preview = document.getElementById('preview');
+const loadTime = new Date();
 let totalTasks = 0;
 for (const [subject, works] of Object.entries(subjects)) {
   const section = document.createElement('section');
@@ -114,14 +115,13 @@ function startParticles(canvas) {
   }
   animate();
 }
-function updateTime() {
-  const now = new Date();
+function displayLoadTime() {
   const fmt = new Intl.DateTimeFormat('zh-CN', {
     year: 'numeric', month: 'long', day: 'numeric',
-    hour: '2-digit', minute: '2-digit', second: '2-digit',
+    hour: '2-digit', minute: '2-digit',
     hour12: false
   });
-  const str = fmt.format(now);
+  const str = fmt.format(loadTime);
   const header = document.getElementById('date');
   header.innerHTML = '';
   for (const ch of str) {
@@ -131,8 +131,7 @@ function updateTime() {
     header.appendChild(span);
   }
 }
-setInterval(updateTime, 1000);
-updateTime();
+displayLoadTime();
 updateProgress();
 
 function wrapChars(el) {


### PR DESCRIPTION
## Summary
- Capture page load time and display it once in header
- Remove live updating seconds clock

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fff17d7a483249f57c1a36e720142