### PR TITLE
Animate subject reorder

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -41,6 +41,7 @@ header {
 }
 .subject {
   margin-bottom: 20px;
+  transition: transform 0.6s;
 }
 .subject h2 {
   margin: 0 0 10px;

--- a/js/main.js
+++ b/js/main.js
@@ -37,23 +37,24 @@ function updateProgress() {
   document.getElementById('progress-text').textContent = percent + '%';
 }
 function checkSubject(section) {
-  const positions = getPositions();
   const checks = section.querySelectorAll('input').length;
   const checked = section.querySelectorAll('input:checked').length;
   if (checks === checked && !section.classList.contains('completed')) {
+    const prevPositions = getPositions();
     section.classList.add('moving');
     setTimeout(() => {
       section.classList.remove('moving');
       section.classList.add('completed', 'fade-in');
       preview.appendChild(section);
       setTimeout(() => section.classList.remove('fade-in'), 600);
-      animateReorder(positions, section);
+      animateReorder(prevPositions, section);
       checkAll();
     }, 600);
   } else if (checked < checks && section.classList.contains('completed')) {
+    const prevPositions = getPositions();
     preview.insertBefore(section, preview.querySelector('.subject:not(.completed)'));
     section.classList.remove('completed');
-    animateReorder(positions, section);
+    animateReorder(prevPositions, section);
   }
 }
 function checkAll() {
@@ -164,14 +165,12 @@ function animateReorder(prev, skip) {
     if (!old) return;
     const dy = old[1] - el.getBoundingClientRect().top;
     if (dy) {
-      el.style.transition = 'transform 0.6s';
+      el.style.transition = 'none';
       el.style.transform = `translateY(${dy}px)`;
       requestAnimationFrame(() => {
+        el.style.transition = '';
         el.style.transform = '';
       });
-      el.addEventListener('transitionend', () => {
-        el.style.transition = '';
-      }, { once: true });
     }
   });
 }


### PR DESCRIPTION
## Summary
- Capture subject positions before completion and animate remaining subjects after moving a completed one.
- Add FLIP-based reorder animation and ensure subjects transition with CSS.
- Introduce `transition: transform 0.6s` for `.subject` elements.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a007657c7c8324b5ecef47cf4f7270