### PR TITLE
Animate progress transitions for tasks

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -28,13 +28,26 @@ for (const [subject, works] of Object.entries(subjects)) {
 }
 wrapChars(document.querySelector('.container'));
 let completedTasks = 0;
+let lastPercent = 0;
+let progressRaf;
 function updateProgress() {
   completedTasks = document.querySelectorAll('#preview input:checked').length;
-  const percent = Math.round((completedTasks / totalTasks) * 100);
+  const target = Math.round((completedTasks / totalTasks) * 100);
   const ring = document.getElementById('progress-ring');
-  const offset = 314 * (1 - completedTasks / totalTasks);
-  ring.style.strokeDashoffset = offset;
-  document.getElementById('progress-text').textContent = percent + '%';
+  const text = document.getElementById('progress-text');
+  cancelAnimationFrame(progressRaf);
+  function step() {
+    if (lastPercent !== target) {
+      lastPercent += lastPercent < target ? 1 : -1;
+      ring.style.strokeDashoffset = 314 * (1 - lastPercent / 100);
+      text.textContent = lastPercent + '%';
+      progressRaf = requestAnimationFrame(step);
+    } else {
+      ring.style.strokeDashoffset = 314 * (1 - lastPercent / 100);
+      text.textContent = lastPercent + '%';
+    }
+  }
+  step();
 }
 function checkSubject(section) {
   const positions = getPositions();


### PR DESCRIPTION
## Summary
- Animate task completion percentage from previous value to new value.
- Keep circular progress ring in sync by adjusting strokeDashoffset during animation.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0076a9dc88324967ae813a7783049