### PR TITLE
feat: add checked task styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5,6 +5,7 @@
   --text: #1d1d1f;
   --muted-text: #6e6e73;
   --border: #d2d2d7;
+  --checked-color: #28a745;
 }
 body {
   margin: 0;
@@ -60,6 +61,7 @@ header {
 .task span {
   position: relative;
   display: inline-block;
+  transition: color 0.5s ease, filter 0.5s ease;
 }
 .task span::after {
   content: "";
@@ -74,9 +76,12 @@ header {
 }
 .task input:checked + span::after {
   width: 100%;
+  background: var(--checked-color);
 }
 .task input:checked + span {
-  color: var(--muted-text);
+  color: var(--checked-color);
+  filter: brightness(80%);
+  transition: color 0.5s ease, filter 0.5s ease;
 }
 .subject.completed {
   opacity: 0.6;


### PR DESCRIPTION
## Summary
- add `--checked-color` root variable for completed task green
- fade checked tasks and strike-through using new color and transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0076b639483248f4f0a502ea9bbb5