### PR TITLE
style: animate checkboxes and use black strikethrough

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -6,6 +6,7 @@
   --muted-text: #6e6e73;
   --border: #d2d2d7;
   --checked-color: #28a745;
+  --strike-color: rgba(0, 0, 0, 0.5);
 }
 body {
   margin: 0;
@@ -55,14 +56,43 @@ header {
   width: 100%;
 }
 .task input {
+  -webkit-appearance: none;
+  appearance: none;
   width: 18px;
   height: 18px;
   margin-right: 10px;
+  border: 2px solid var(--border);
+  border-radius: 4px;
+  position: relative;
+  cursor: pointer;
+  transition: border-color 0.3s ease;
+}
+
+.task input::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: 0px;
+  width: 5px;
+  height: 10px;
+  border: solid var(--checked-color);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) scale(0);
+  transform-origin: bottom left;
+  transition: transform 0.3s ease;
+}
+
+.task input:checked {
+  border-color: var(--checked-color);
+}
+
+.task input:checked::after {
+  transform: rotate(45deg) scale(1);
 }
 .task span {
   position: relative;
   display: inline-block;
-  transition: color 0.5s ease, filter 0.5s ease;
+  transition: color 0.5s ease;
 }
 .task span::after {
   content: "";
@@ -70,19 +100,18 @@ header {
   left: 0;
   top: 50%;
   height: 2px;
-  background: var(--accent-color);
+  background: var(--strike-color);
   width: 0;
   transform: translateY(-50%);
   transition: width 0.5s ease;
 }
 .task input:checked + span::after {
   width: 100%;
-  background: var(--checked-color);
+  background: var(--strike-color);
 }
 .task input:checked + span {
-  color: var(--checked-color);
-  filter: brightness(80%);
-  transition: color 0.5s ease, filter 0.5s ease;
+  color: var(--strike-color);
+  transition: color 0.5s ease;
 }
 .subject.completed {
   opacity: 0.6;


### PR DESCRIPTION
## Summary
- animate checkbox tick with green color on completion
- render strike-through line and completed text in semi-transparent black

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a00f5b2c148324b7952a8d335f3cf4