### PR TITLE
fix: keep preview scrollbar within border

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -39,6 +39,7 @@ header {
   padding: 20px;
   height: 400px;
   overflow: auto;
+  scrollbar-gutter: stable;
   color: var(--text);
 }
 .subject {


### PR DESCRIPTION
## Summary
- reserve space for preview scrollbar so it doesn't exceed the border radius

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0652bd6f88324aa685b50d47610db