### PR TITLE
fix: keep preview scrollbar within border

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -38,7 +38,8 @@ header {
   margin-top: 20px;
   padding: 20px;
   height: 400px;
-  overflow: auto;
+  overflow-y: scroll;
+  padding-right: 10px;
   color: var(--text);
 }
 .subject {


### PR DESCRIPTION
## Summary
- ensure preview scrollbar stays inside rounded border by forcing vertical scrollbars and adding right padding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0652bd6f88324aa685b50d47610db