### PR TITLE
fix: prevent preview scrollbar overlap

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -30,20 +30,24 @@ header {
   font-weight: 600;
   color: var(--text);
 }
-#preview {
+.preview-card {
   background: var(--card-bg);
   border-radius: 16px;
   border: 1px solid var(--border);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
   margin-top: 20px;
+  overflow: hidden;
+  background-clip: padding-box;
+}
+
+#preview {
   padding: 20px;
+  padding-right: 28px;
   height: 400px;
-codex/add-scrollbar-styling-to-preview-33zt9n
-  overflow-y: scroll;
-  padding-right: 10px;
   overflow: auto;
-  scrollbar-gutter: stable;
+  scrollbar-gutter: stable both-edges;
   color: var(--text);
+  -webkit-overflow-scrolling: touch;
 }
 .subject {
   margin-bottom: 20px;

--- a/index.html
+++ b/index.html
@@ -9,7 +9,9 @@
 <body>
 <div class="container">
   <header id="date"></header>
-  <div id="preview"></div>
+  <div class="preview-card">
+    <div id="preview"></div>
+  </div>
   <div id="progress">
     <svg width="120" height="120">
       <circle cx="60" cy="60" r="50" stroke="#d2d2d7" stroke-width="10" fill="none" />


### PR DESCRIPTION
## Summary
- wrap preview content in `.preview-card` to clip the scrollbar within rounded corners
- separate scrolling styles from card visuals, removing stray overflow rules

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a07223212483249bf9e8d1210e13cc