### PR TITLE
Make progress donut chart green

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,5 +1,5 @@
 :root {
-  --accent-color: #007aff;
+  --accent-color: #28a745;
   --bg: #f5f5f7;
   --card-bg: #ffffff;
   --text: #1d1d1f;


### PR DESCRIPTION
## Summary
- switch accent color to green for progress donut chart

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/shiheishan.github.io/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a073edec5c83249558e9fea8b5d6dd