### PR TITLE
feat: add glass card fallback

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -40,6 +40,13 @@ header {
   background-clip: padding-box;
 }
 
+.glass-card {
+  background-color: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+
 #preview {
   padding: 20px;
   padding-right: 28px;

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
 <div class="container">
   <header id="date"></header>
-  <div class="preview-card">
+  <div class="preview-card glass-card">
     <div id="preview"></div>
   </div>
   <div id="progress">


### PR DESCRIPTION
## Summary
- add `.glass-card` style with translucent background and border fallback for browsers without `backdrop-filter`
- apply `.glass-card` to preview card to use new glass effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0766a2108832489787291230464c4