### PR TITLE
Clean duplicate markup and fix progress ring

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,7 +7,6 @@
   --border: #d2d2d7;
   --checked-color: #28a745;
   --strike-color: rgba(0, 0, 0, 0.5);
-codex/add-glassmorphism-theme-and-styles
   --glass-bg: rgba(255, 255, 255, 0.2);
   --glass-border: rgba(255, 255, 255, 0.3);
   --glass-highlight: rgba(255, 255, 255, 0.25);
@@ -51,7 +50,6 @@ header {
 }
 
 .glass-card {
-codex/add-fallback-styles-for-.glass-card
   background-color: rgba(255, 255, 255, 0.2);
   border: 1px solid rgba(255, 255, 255, 0.3);
   -webkit-backdrop-filter: blur(10px);

--- a/index.html
+++ b/index.html
@@ -7,37 +7,23 @@
 <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body>
-codex/add-glassmorphism-theme-and-styles
-<div class="container">
-codex/add-fallback-styles-for-.glass-card
-  <header id="date"></header>
-  <header id="date" class="glass-card"></header>
-  <div class="preview-card glass-card">
-    <div id="preview"></div>
-  </div>
-  <div id="progress">
-    <svg width="120" height="120">
-      <circle cx="60" cy="60" r="50" stroke="#d2d2d7" stroke-width="10" fill="none" />
-      <circle id="progress-ring" cx="60" cy="60" r="50" stroke-width="10" fill="none" stroke-linecap="round" stroke-dasharray="314" stroke-dashoffset="314" transform="rotate(-90 60 60)" />
-      <text id="progress-text" x="60" y="60" text-anchor="middle" dominant-baseline="central" font-size="20">0%</text>
-    </svg>
-<div class="aurora-bg"></div>
-<div class="relative z-10">
-  <div class="container">
-    <header id="date"></header>
-    <div class="preview-card">
-      <div id="preview"></div>
-    </div>
-    <div id="progress">
-      <svg width="120" height="120">
-        <circle cx="60" cy="60" r="50" stroke="#d2d2d7" stroke-width="10" fill="none" />
-        <circle id="progress-ring" cx="60" cy="60" r="50" stroke-width="10" fill="none" stroke-linecap="round" stroke-dasharray="314" stroke-dashoffset="314" transform="rotate(-90 60 60)" />
-        <text id="progress-text" x="60" y="60" text-anchor="middle" dominant-baseline="central" font-size="20">0%</text>
-      </svg>
+  <div class="aurora-bg"></div>
+  <div class="relative z-10">
+    <div class="container">
+      <header id="date"></header>
+      <div class="preview-card">
+        <div id="preview"></div>
+      </div>
+      <div id="progress">
+        <svg width="120" height="120">
+          <circle cx="60" cy="60" r="50" stroke="#d2d2d7" stroke-width="10" fill="none" />
+          <circle id="progress-ring" cx="60" cy="60" r="50" stroke-width="10" fill="none" stroke-linecap="round" stroke-dasharray="314" stroke-dashoffset="314" transform="rotate(-90 60 60)" />
+          <text id="progress-text" x="60" y="60" text-anchor="middle" dominant-baseline="central" font-size="20">0%</text>
+        </svg>
+      </div>
     </div>
   </div>
-</div>
-<div id="final-overlay" style="display:none"></div>
-<script type="module" src="js/main.js"></script>
+  <div id="final-overlay" style="display:none"></div>
+  <script type="module" src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove stray `codex/` strings and redundant container/header elements
- ensure progress ring uses `stroke-dasharray="314"`
- tidy CSS variables and glass-card styling

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a079ea74a483249da3c38329b893ae