### PR TITLE
chore: clean up glassmorphism styles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,7 +7,6 @@
   --border: #d2d2d7;
   --checked-color: #28a745;
   --strike-color: rgba(0, 0, 0, 0.5);
-codex/add-glassmorphism-theme-and-styles
   --glass-bg: rgba(255, 255, 255, 0.2);
   --glass-border: rgba(255, 255, 255, 0.3);
   --glass-highlight: rgba(255, 255, 255, 0.25);
@@ -51,7 +50,6 @@ header {
 }
 
 .glass-card {
-codex/add-fallback-styles-for-.glass-card
   background-color: rgba(255, 255, 255, 0.2);
   border: 1px solid rgba(255, 255, 255, 0.3);
   -webkit-backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- remove stray codex placeholders from styles
- ensure glassmorphism variables and `.glass-card` rule are syntactically correct

## Testing
- `npx --yes stylelint css/styles.css` *(fails: No configuration provided)*
- `python3 -m http.server 8000 && curl -s http://localhost:8000/css/styles.css | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68a079ed33e88324a56a6c205c547d8b