### PR TITLE
Simplify layout with plain white background

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,92 +1,54 @@
 :root {
-  --accent-color: #28a745;
-  --bg: #f5f5f7;
-  --card-bg: #ffffff;
   --text: #1d1d1f;
-  --muted-text: #6e6e73;
   --border: #d2d2d7;
   --checked-color: #28a745;
-  --strike-color: rgba(0, 0, 0, 0.5);
-  --glass-bg: rgba(255, 255, 255, 0.2);
-  --glass-border: rgba(255, 255, 255, 0.3);
-  --glass-highlight: rgba(255, 255, 255, 0.25);
-  --blur: 10px;
-  --radius: 16px;
-  --c1: #4f46e5;
-  --c2: #0ea5e9;
-  --c3: #10b981;
-  --c4: #f472b6;
 }
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
-  background: var(--bg);
+  background: #ffffff;
   color: var(--text);
 }
+
 .container {
   width: 90%;
   max-width: 420px;
   margin: 20px auto;
 }
+
 header {
-  background: var(--card-bg);
-  border-radius: 16px;
   border: 1px solid var(--border);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+  border-radius: 16px;
   padding: 15px;
   text-align: center;
   font-size: 24px;
   font-weight: 600;
-  color: var(--text);
-}
-.preview-card {
-  background: var(--card-bg);
-  border-radius: 16px;
-  border: 1px solid var(--border);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
-  margin-top: 20px;
-  overflow: hidden;
-  background-clip: padding-box;
-}
-
-.glass-card {
-  background-color: rgba(255, 255, 255, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)), var(--glass-bg);
-  backdrop-filter: blur(var(--blur)) saturate(140%);
-  border: 1px solid var(--glass-border);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35), inset 0 1px 0 var(--glass-highlight);
-  border-radius: var(--radius);
 }
 
 #preview {
-  padding: 20px;
-  padding-right: 28px;
-  height: 400px;
-  overflow: auto;
-  scrollbar-gutter: stable both-edges;
-  color: var(--text);
-  -webkit-overflow-scrolling: touch;
+  margin-top: 20px;
 }
+
 .subject {
   margin-bottom: 20px;
-  transition: transform 0.6s;
 }
+
 .subject h2 {
   margin: 0 0 10px;
   font-size: 20px;
 }
+
 .task {
   display: flex;
   align-items: center;
   margin-bottom: 8px;
-  width: 100%;
 }
+
 .task input {
   display: none;
 }
+
 .task .checkbox {
   -webkit-appearance: none;
   appearance: none;
@@ -97,9 +59,9 @@ header {
   border-radius: 4px;
   position: relative;
   flex-shrink: 0;
-  transition: border-color 0.3s ease;
   cursor: pointer;
 }
+
 .task .checkbox::after {
   content: "";
   position: absolute;
@@ -113,164 +75,15 @@ header {
   transform-origin: bottom left;
   transition: transform 0.3s ease;
 }
+
 .task input:checked + .checkbox {
   border-color: var(--checked-color);
 }
+
 .task input:checked + .checkbox::after {
   transform: rotate(45deg) scale(1);
 }
+
 .task .text {
-  position: relative;
-  display: inline-block;
-  transition: color 0.5s ease;
-}
-.task .text::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 50%;
-  height: 2px;
-  background: var(--strike-color);
-  width: 0;
-  transform: translateY(-50%);
-  transition: width 0.5s ease;
-}
-.task input:checked ~ .text::after {
-  width: 100%;
-  background: var(--strike-color);
-}
-.task input:checked ~ .text {
-  color: var(--strike-color);
-  transition: color 0.5s ease;
-}
-.subject.completed {
-  opacity: 0.6;
-}
-.subject.moving {
-  animation: slideOut 0.6s forwards;
-}
-@keyframes slideOut {
-  to {
-    transform: translateY(20px);
-    opacity: 0;
-  }
-}
-.subject.fade-in {
-  animation: fadeIn 0.6s forwards;
-}
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 0.6; }
-}
-#progress {
-  margin-top: 20px;
-  text-align: center;
-  color: var(--muted-text);
-}
-#progress-ring {
-  stroke: var(--accent-color);
-  transition: stroke-dashoffset 0.5s ease;
-}
-#progress-text {
-  fill: var(--accent-color);
-  transition: 0.5s;
-}
-#final-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(255, 255, 255, 0.9);
-  color: var(--text);
-  z-index: 999;
-  display: none;
-}
-#particle-canvas {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-.char {
-  display: inline-block;
-}
-.container.disintegrate .char {
-  animation: disperse 1s forwards;
-}
-@keyframes disperse {
-  to {
-    opacity: 0;
-    transform: translate(var(--dx), var(--dy)) rotate(30deg);
-  }
-}
-#final-text {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%) scale(0.8);
-  font-size: 32px;
-  color: var(--text);
-  opacity: 0;
-  transition: opacity 1s, transform 1s;
-}
-#final-text.show {
-  opacity: 1;
-  transform: translate(-50%, -50%) scale(1);
-}
-
-.relative {
-  position: relative;
-}
-
-.z-10 {
-  z-index: 10;
-}
-
-.aurora-bg {
-  position: fixed;
-  inset: 0;
-  overflow: hidden;
-  pointer-events: none;
-  z-index: -1;
-}
-
-.aurora-bg::before,
-.aurora-bg::after {
-  content: "";
-  position: absolute;
-  width: 200%;
-  height: 200%;
-  top: -50%;
-  left: -50%;
-  animation: auroraShift 25s ease-in-out infinite;
-  filter: blur(80px) saturate(150%);
-  opacity: 0.7;
-}
-
-.aurora-bg::before {
-  background: radial-gradient(circle at 20% 20%, var(--c1), transparent 60%),
-              radial-gradient(circle at 80% 30%, var(--c2), transparent 60%);
-}
-
-.aurora-bg::after {
-  background: radial-gradient(circle at 30% 70%, var(--c3), transparent 60%),
-              radial-gradient(circle at 70% 80%, var(--c4), transparent 60%);
-  animation-direction: reverse;
-}
-
-@keyframes auroraShift {
-  0% {
-    transform: rotate(0deg) scale(1);
-    filter: blur(60px) saturate(120%);
-  }
-  50% {
-    transform: rotate(180deg) scale(1.2);
-    filter: blur(80px) saturate(200%);
-  }
-  100% {
-    transform: rotate(360deg) scale(1);
-    filter: blur(60px) saturate(120%);
-  }
+  flex: 1;
 }

--- a/index.html
+++ b/index.html
@@ -1,32 +1,16 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-<meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>作业预览</title>
-<link rel="stylesheet" href="css/styles.css" />
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>作业预览</title>
+  <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body>
-  <div class="aurora-bg"></div>
-  <div class="relative z-10">
-    <div class="container">
-codex/fix-duplicate-id-in-index.html
-      <header id="date" class="glass-card"></header>
-      <div class="preview-card glass-card">
-      <header id="date"></header>
-      <div class="preview-card">
-        <div id="preview"></div>
-      </div>
-      <div id="progress">
-        <svg width="120" height="120">
-          <circle cx="60" cy="60" r="50" stroke="#d2d2d7" stroke-width="10" fill="none" />
-          <circle id="progress-ring" cx="60" cy="60" r="50" stroke-width="10" fill="none" stroke-linecap="round" stroke-dasharray="314" stroke-dashoffset="314" transform="rotate(-90 60 60)" />
-          <text id="progress-text" x="60" y="60" text-anchor="middle" dominant-baseline="central" font-size="20">0%</text>
-        </svg>
-      </div>
-    </div>
+  <div class="container">
+    <header id="date"></header>
+    <div id="preview"></div>
   </div>
-  <div id="final-overlay" style="display:none"></div>
   <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,8 @@
 import subjects from '../data/subjects.js';
+
 const preview = document.getElementById('preview');
 const loadTime = new Date();
-let totalTasks = 0;
+
 for (const [subject, works] of Object.entries(subjects)) {
   const section = document.createElement('section');
   section.className = 'subject';
@@ -9,7 +10,6 @@ for (const [subject, works] of Object.entries(subjects)) {
   h2.textContent = subject;
   section.appendChild(h2);
   works.forEach(work => {
-    totalTasks++;
     const label = document.createElement('label');
     label.className = 'task';
     const input = document.createElement('input');
@@ -23,173 +23,17 @@ for (const [subject, works] of Object.entries(subjects)) {
     label.appendChild(box);
     label.appendChild(text);
     section.appendChild(label);
-    input.addEventListener('change', () => {
-      updateProgress();
-      checkSubject(section);
-    });
   });
   preview.appendChild(section);
 }
-wrapChars(document.querySelector('.container'));
-let completedTasks = 0;
-let lastPercent = 0;
-let progressRaf;
-function updateProgress() {
-  completedTasks = document.querySelectorAll('#preview input:checked').length;
-  const target = Math.round((completedTasks / totalTasks) * 100);
-  const ring = document.getElementById('progress-ring');
-  const text = document.getElementById('progress-text');
-  cancelAnimationFrame(progressRaf);
-  function step() {
-    if (lastPercent !== target) {
-      lastPercent += lastPercent < target ? 1 : -1;
-      ring.style.strokeDashoffset = 314 * (1 - lastPercent / 100);
-      text.textContent = lastPercent + '%';
-      progressRaf = requestAnimationFrame(step);
-    } else {
-      ring.style.strokeDashoffset = 314 * (1 - lastPercent / 100);
-      text.textContent = lastPercent + '%';
-    }
-  }
-  step();
-}
-function checkSubject(section) {
-  const checks = section.querySelectorAll('input').length;
-  const checked = section.querySelectorAll('input:checked').length;
-  if (checks === checked && !section.classList.contains('completed')) {
-    const prevPositions = getPositions();
-    section.classList.add('moving');
-    setTimeout(() => {
-      section.classList.remove('moving');
-      section.classList.add('completed', 'fade-in');
-      preview.appendChild(section);
-      setTimeout(() => section.classList.remove('fade-in'), 600);
-      animateReorder(prevPositions, section);
-      checkAll();
-    }, 600);
-  } else if (checked < checks && section.classList.contains('completed')) {
-    const prevPositions = getPositions();
-    preview.insertBefore(section, preview.querySelector('.subject:not(.completed)'));
-    section.classList.remove('completed');
-    animateReorder(prevPositions, section);
-  }
-}
-function checkAll() {
-  const total = document.querySelectorAll('.subject').length;
-  const done = document.querySelectorAll('.subject.completed').length;
-  if (total === done) {
-    showFinal();
-  }
-}
-function showFinal() {
-  const container = document.querySelector('.container');
-  wrapChars(container);
-  const chars = container.querySelectorAll('.char');
-  chars.forEach(span => {
-    span.style.setProperty('--dx', (Math.random() - 0.5) * 200 + 'px');
-    span.style.setProperty('--dy', (Math.random() - 0.5) * 200 + 'px');
-  });
-  container.classList.add('disintegrate');
-  setTimeout(() => {
-    container.style.display = 'none';
-    const overlay = document.getElementById('final-overlay');
-    overlay.style.display = 'block';
-    const canvas = document.createElement('canvas');
-    canvas.id = 'particle-canvas';
-    overlay.appendChild(canvas);
-    startParticles(canvas);
-    setTimeout(() => {
-      canvas.remove();
-      const text = document.createElement('div');
-      text.id = 'final-text';
-      text.textContent = '今日任务完成，请好好休息';
-      overlay.appendChild(text);
-      wrapChars(text);
-      requestAnimationFrame(() => text.classList.add('show'));
-    }, 1500);
-  }, 1000);
-}
-function startParticles(canvas) {
-  const ctx = canvas.getContext('2d');
-  canvas.width = innerWidth;
-  canvas.height = innerHeight;
-  const particles = Array.from({ length: 100 }, () => ({
-    x: Math.random() * canvas.width,
-    y: Math.random() * canvas.height,
-    vx: (Math.random() - 0.5) * 4,
-    vy: (Math.random() - 0.5) * 4,
-    alpha: 1
-  }));
-  function animate() {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    particles.forEach(p => {
-      p.x += p.vx;
-      p.y += p.vy;
-      p.alpha -= 0.02;
-      ctx.fillStyle = `rgba(255,255,255,${p.alpha})`;
-      ctx.fillRect(p.x, p.y, 3, 3);
-    });
-    if (particles.some(p => p.alpha > 0)) {
-      requestAnimationFrame(animate);
-    }
-  }
-  animate();
-}
+
 function displayLoadTime() {
   const fmt = new Intl.DateTimeFormat('zh-CN', {
     year: 'numeric', month: 'long', day: 'numeric',
-    hour: '2-digit', minute: '2-digit',second: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
     hour12: false
   });
-  const str = fmt.format(loadTime);
-  const header = document.getElementById('date');
-  header.innerHTML = '';
-  for (const ch of str) {
-    const span = document.createElement('span');
-    span.className = 'char';
-    span.textContent = ch;
-    header.appendChild(span);
-  }
+  document.getElementById('date').textContent = fmt.format(loadTime);
 }
+
 displayLoadTime();
-updateProgress();
-
-function wrapChars(el) {
-  el.childNodes.forEach(node => {
-    if (node.nodeType === 3) {
-      const frag = document.createDocumentFragment();
-      node.textContent.split('').forEach(ch => {
-        const span = document.createElement('span');
-        span.textContent = ch;
-        span.className = 'char';
-        frag.appendChild(span);
-      });
-      node.parentNode.replaceChild(frag, node);
-    } else if (node.nodeType === 1) {
-      if (node.namespaceURI !== 'http://www.w3.org/2000/svg') {
-        wrapChars(node);
-      }
-    }
-  });
-}
-
-function getPositions() {
-  return Array.from(preview.children).map(el => [el, el.getBoundingClientRect().top]);
-}
-
-function animateReorder(prev, skip) {
-  Array.from(preview.children).forEach(el => {
-    if (el === skip) return;
-    const old = prev.find(p => p[0] === el);
-    if (!old) return;
-    const dy = old[1] - el.getBoundingClientRect().top;
-    if (dy) {
-      el.style.transition = 'none';
-      el.style.transform = `translateY(${dy}px)`;
-      requestAnimationFrame(() => {
-        el.style.transition = '';
-        el.style.transform = '';
-      });
-    }
-  });
-}


### PR DESCRIPTION
## Summary
- Remove decorative aurora background and progress elements
- Display only time and task list on a clean white canvas
- Streamline scripts to just render assignments and timestamp

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a08f28d0f88324a55758da089b2ad1