### PR TITLE
feat: add interactive homework progress features

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -28,6 +28,12 @@ header {
 
 #preview {
   margin-top: 20px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 15px;
+  background: #ffffff;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 .subject {
@@ -38,6 +44,7 @@ header {
   margin: 0 0 10px;
   font-size: 20px;
 }
+
 
 .task {
   display: flex;
@@ -86,4 +93,40 @@ header {
 
 .task .text {
   flex: 1;
+}
+
+.task input:checked ~ .text {
+  text-decoration: line-through;
+  color: rgba(0, 0, 0, 0.5);
+}
+
+#progress {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+}
+
+#progress svg {
+  width: 100px;
+  height: 100px;
+}
+
+#progress .bg {
+  fill: none;
+  stroke: var(--border);
+  stroke-width: 3.8;
+}
+
+#progress .meter {
+  fill: none;
+  stroke: var(--checked-color);
+  stroke-width: 3.8;
+  stroke-linecap: round;
+  transition: stroke-dasharray 0.3s ease;
+}
+
+#progress .percentage {
+  font-size: 0.5em;
+  text-anchor: middle;
+  fill: var(--text);
 }

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <div class="container">
     <header id="date"></header>
     <div id="preview"></div>
+    <div id="progress"></div>
   </div>
   <script type="module" src="js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,22 @@ import subjects from '../data/subjects.js';
 
 const preview = document.getElementById('preview');
 const loadTime = new Date();
+const progressContainer = document.getElementById('progress');
+let totalTasks = 0;
+
+progressContainer.innerHTML = `
+  <svg viewBox="0 0 36 36">
+    <path class="bg" d="M18 2.0845
+      a 15.9155 15.9155 0 0 1 0 31.831
+      a 15.9155 15.9155 0 0 1 0 -31.831" />
+    <path class="meter" stroke-dasharray="0,100" d="M18 2.0845
+      a 15.9155 15.9155 0 0 1 0 31.831
+      a 15.9155 15.9155 0 0 1 0 -31.831" />
+    <text x="18" y="20.35" class="percentage">0%</text>
+  </svg>
+`;
+const meter = progressContainer.querySelector('.meter');
+const percentageText = progressContainer.querySelector('.percentage');
 
 for (const [subject, works] of Object.entries(subjects)) {
   const section = document.createElement('section');
@@ -9,6 +25,8 @@ for (const [subject, works] of Object.entries(subjects)) {
   const h2 = document.createElement('h2');
   h2.textContent = subject;
   section.appendChild(h2);
+  const tasksDiv = document.createElement('div');
+  tasksDiv.className = 'tasks';
   works.forEach(work => {
     const label = document.createElement('label');
     label.className = 'task';
@@ -22,9 +40,21 @@ for (const [subject, works] of Object.entries(subjects)) {
     label.appendChild(input);
     label.appendChild(box);
     label.appendChild(text);
-    section.appendChild(label);
+    tasksDiv.appendChild(label);
+    totalTasks++;
   });
+  section.appendChild(tasksDiv);
   preview.appendChild(section);
+}
+
+const checkboxes = preview.querySelectorAll('input[type="checkbox"]');
+checkboxes.forEach(cb => cb.addEventListener('change', updateProgress));
+
+function updateProgress() {
+  const checked = preview.querySelectorAll('input:checked').length;
+  const percent = totalTasks === 0 ? 0 : Math.round((checked / totalTasks) * 100);
+  meter.setAttribute('stroke-dasharray', `${percent},100`);
+  percentageText.textContent = `${percent}%`;
 }
 
 function displayLoadTime() {
@@ -35,5 +65,5 @@ function displayLoadTime() {
   });
   document.getElementById('date').textContent = fmt.format(loadTime);
 }
-
 displayLoadTime();
+updateProgress();


### PR DESCRIPTION
## Summary
- add donut progress chart updating with completed tasks
- show all homework tasks expanded in a scrollable panel
- strike through completed tasks in semi-transparent text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a090c1efcc8324b4e32167687998fc