### PR TITLE
fix: remove stray markers from script and style

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -27,15 +27,14 @@ header {
 }
 
 #preview {
-  margin-top: 20px;
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 15px;
-  background: #ffffff;
-codex/add-border-to-work-area-e5rtin
-  max-height: 300px;
-  overflow-y: auto;
-}
+    margin-top: 20px;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 15px;
+    background: #ffffff;
+    max-height: 300px;
+    overflow-y: auto;
+  }
 
 .subject {
   margin-bottom: 20px;

--- a/js/main.js
+++ b/js/main.js
@@ -40,11 +40,10 @@ for (const [subject, works] of Object.entries(subjects)) {
     label.appendChild(input);
     label.appendChild(box);
     label.appendChild(text);
-    tasksDiv.appendChild(label);
-    totalTasks++;
-codex/add-border-to-work-area-e5rtin
-  });
-  section.appendChild(tasksDiv);
+      tasksDiv.appendChild(label);
+      totalTasks++;
+    });
+    section.appendChild(tasksDiv);
   h2.addEventListener('click', () => {
     if (section.classList.contains('open')) {
       tasksDiv.style.maxHeight = '0';
@@ -53,7 +52,6 @@ codex/add-border-to-work-area-e5rtin
     }
     section.classList.toggle('open');
   });
-  section.appendChild(tasksDiv);
   preview.appendChild(section);
 }
 


### PR DESCRIPTION
## Summary
- remove accidental marker text from main script and styles
- streamline DOM builder by eliminating redundant append call

## Testing
- `node --check js/main.js`
- `npx stylelint css/styles.css --config /tmp/stylelint.config.json`


------
https://chatgpt.com/codex/tasks/task_e_68a09b5dceb483249f37a7a377a7e7d1