### PR TITLE
Expand tasks by default in homework preview

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -53,6 +53,8 @@ for (const [subject, works] of Object.entries(subjects)) {
     section.classList.toggle('open');
   });
   preview.appendChild(section);
+  tasksDiv.style.maxHeight = tasksDiv.scrollHeight + 'px';
+  section.classList.add('open');
 }
 
 const checkboxes = preview.querySelectorAll('input[type="checkbox"]');


### PR DESCRIPTION
## Summary
- Expand task lists by default when rendering subjects

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a09dd4435483249bec1fce535acfde