### PR TITLE
feat: animate checkbox strike-through

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -100,10 +100,27 @@ header {
 
 .task .text {
   flex: 1;
+  position: relative;
+  transition: color 0.3s ease;
+}
+
+.task .text::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 0;
+  height: 1px;
+  background: rgba(0, 0, 0, 0.5);
+  transform: translateY(-50%);
+  transition: width 0.3s ease;
+}
+
+.task input:checked ~ .text::after {
+  width: 100%;
 }
 
 .task input:checked ~ .text {
-  text-decoration: line-through;
   color: rgba(0, 0, 0, 0.5);
 }
 


### PR DESCRIPTION
## Summary
- animate strike-through across task text when checkbox is checked
- fade text to semi-transparent black along with strike-through

## Testing
- `npm test` (fails: ENOENT package.json)
- `npm run lint` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a09fb12ad48324b4d2a23ed9acc4ed