### PR TITLE
Remove progress box from homework page

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,9 +65,13 @@ function updateProgress(){
   const done = inputs.filter(i=>i.checked).length;
   const pct = total ? Math.round(done/total*100) : 100;
 
-  ring.style.strokeDasharray = CIRCUM;
-  ring.style.strokeDashoffset = (1 - pct/100) * CIRCUM;
-  pctText.textContent = pct + '%';
+  if(ring){
+    ring.style.strokeDasharray = CIRCUM;
+    ring.style.strokeDashoffset = (1 - pct/100) * CIRCUM;
+  }
+  if(pctText){
+    pctText.textContent = pct + '%';
+  }
 
   if(done === total && total > 0){
     celebrateAndVanish();

--- a/index.html
+++ b/index.html
@@ -19,28 +19,6 @@
         <section>
           <div id="subjects"></div>
         </section>
-        <aside class="aside">
-          <h3>今日进度</h3>
-          <div class="donut">
-            <svg viewBox="0 0 160 160" aria-hidden="true">
-              <defs>
-                <filter id="innershadow" x="-50%" y="-50%" width="200%" height="200%">
-                  <feOffset dx="0" dy="2"/>
-                  <feGaussianBlur stdDeviation="2" result="offset-blur"/>
-                  <feComposite operator="out" in="SourceGraphic" in2="offset-blur" result="inverse"/>
-                  <feFlood flood-color="#000" flood-opacity="0.25" result="color"/>
-                  <feComposite operator="in" in="color" in2="inverse" result="shadow"/>
-                  <feComposite operator="over" in="shadow" in2="SourceGraphic"/>
-                </filter>
-              </defs>
-              <circle cx="80" cy="80" r="60" fill="#fff" filter="url(#innershadow)" />
-              <circle cx="80" cy="80" r="60" fill="none" stroke="#e6e6ea" stroke-width="16"/>
-              <circle id="ring" cx="80" cy="80" r="60" fill="none" stroke="var(--accent)" stroke-width="16" stroke-linecap="round" stroke-dasharray="377" stroke-dashoffset="377" transform="rotate(-90 80 80)"/>
-              <text x="80" y="80" class="pct" id="pctText">0%</text>
-            </svg>
-          </div>
-          <div class="hint">勾选作业可更新进度；全部完成后页面会“离子消除”。</div>
-        </aside>
       </div>
 
       <div class="done-screen" id="done">

--- a/styles.css
+++ b/styles.css
@@ -48,8 +48,7 @@ body{
 }
 
 /* 内容布局 */
-.content{ margin-top:18px; display:grid; grid-template-columns: 1fr 310px; gap:18px; }
-@media (max-width: 900px){ .content{ grid-template-columns: 1fr; } }
+.content{ margin-top:18px; }
 
 /* 学科卡片（回归白卡片风格） */
 .subject{


### PR DESCRIPTION
## Summary
- drop progress donut box from main page
- simplify layout styles and guard progress references

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a15ac3a8a88324a47e8e75bee18343