### PR TITLE
refactor: remove paper container and styles

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,6 @@ const subjectsEl = document.getElementById('subjects');
 const ring = document.getElementById('ring');
 const pctText = document.getElementById('pctText');
 const app = document.getElementById('app');
-const paper = document.getElementById('paper');
 const ionCanvas = document.getElementById('ion-canvas');
 
 const CIRCUM = 2 * Math.PI * 60; // r = 60
@@ -93,7 +92,7 @@ function celebrateAndVanish(){
   if(document.body.classList.contains('disintegrate')) return;
   document.body.classList.add('disintegrate');
 
-  const rect = paper.getBoundingClientRect();
+  const rect = app.getBoundingClientRect();
   const cw = ionCanvas.width = rect.width * (window.devicePixelRatio || 1);
   const ch = ionCanvas.height = rect.height * (window.devicePixelRatio || 1);
   const ctx = ionCanvas.getContext('2d');
@@ -131,9 +130,7 @@ function celebrateAndVanish(){
     if(alive>0){
       requestAnimationFrame(step);
     }else{
-      paper.style.display = 'none';
-      const root = document.getElementById('app');
-      root.classList.add('show-done');
+        app.classList.add('show-done');
     }
   }
   requestAnimationFrame(step);

--- a/index.html
+++ b/index.html
@@ -10,24 +10,22 @@
   <div class="wrap" id="app">
     <canvas id="ion-canvas"></canvas>
 
-    <main class="paper" id="paper">
-      <div class="date-card" aria-live="polite">
-        <span id="now">——</span>
-      </div>
+    <div class="date-card" aria-live="polite">
+      <span id="now">——</span>
+    </div>
 
-      <div class="content">
-        <section>
-          <div id="subjects"></div>
-        </section>
-      </div>
+    <div class="content">
+      <section>
+        <div id="subjects"></div>
+      </section>
+    </div>
 
-      <div class="done-screen" id="done">
-        <div class="card">
-          <h1>今日任务已完成</h1>
-          <p>请好好休息。</p>
-        </div>
+    <div class="done-screen" id="done">
+      <div class="card">
+        <h1>今日任务已完成</h1>
+        <p>请好好休息。</p>
       </div>
-    </main>
+    </div>
   </div>
 
   <script src="app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,6 @@
 /* ===== iOS 拟物，白色背景（无流动背景），删除线回调为半黑 ===== */
 :root{
   --bg:#f5f5f7;
-  --paper:#f9f9f7;
   --ink:#1d1d1f;
   --muted:#6e6e73;
   --accent:#34c759;
@@ -13,7 +12,7 @@
 @media (prefers-color-scheme: dark){
   :root{
     --bg:#0f1115;
-    --paper:#16181d; --ink:#f2f2f7; --muted:#a1a1a6; --border:#2c2c2e;
+    --ink:#f2f2f7; --muted:#a1a1a6; --border:#2c2c2e;
     --card:#0f1115e6; --strike:rgba(255,255,255,.5);
   }
 }
@@ -28,15 +27,6 @@ body{
 }
 
 .wrap{ min-height:100%; display:grid; place-items:center; padding:32px; }
-
-/* 主纸面（外框仍去除，根据你之前要求） */
-.paper{
-  width:min(880px, 94vw); min-height:82vh;
-  background:var(--paper);
-  border-radius:28px; position:relative; padding:28px 28px 20px;
-  box-shadow:none;
-  overflow:hidden;
-}
 
 /* 时间卡片（可留玻璃风格，也可换为纯白卡片） */
 .date-card{
@@ -119,14 +109,6 @@ body{
 .done-screen .card{ background:#fff; border:1px solid var(--border); border-radius:22px; padding:28px 22px; box-shadow:0 12px 26px rgba(0,0,0,.12), inset 0 1px 0 rgba(255,255,255,.5); }
 .done-screen h1{ margin:0 0 6px; font-size:22px; }
 .done-screen p{ margin:0; color:var(--muted); }
-
-/* 离子消除 */
-.disintegrate .paper{ animation: paper-out .9s ease forwards; }
-@keyframes paper-out{
-  0%{filter:none; opacity:1; transform:translateY(0) scale(1);}
-  60%{filter:blur(2px); opacity:.6;}
-  100%{filter:blur(8px); opacity:0; transform:translateY(10px) scale(.98);}
-}
 
 /* 小提示 */
 .hint{ margin:10px 0 0; font-size:12px; color:var(--muted); }


### PR DESCRIPTION
## Summary
- remove the paper wrapper from the DOM and lift its children
- drop paper-related CSS variables, styles and animations
- update JS to reference the app container for completion handling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a15eb188388324a57eb5d04a021a5e