### PR TITLE
fix: adjust layout to raise time and tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,6 @@
         <text id="pctText" class="pct" x="70" y="76">0%</text>
       </svg>
     </div>
-</section>
-    </div>
 
     <div class="done-screen" id="done">
       <div class="card">

--- a/styles.css
+++ b/styles.css
@@ -154,3 +154,11 @@ body{
 .donut .track{ stroke:#e5e5ea; }
 .donut .ring{ stroke:var(--accent); transform-origin:50% 50%; transform:rotate(-90deg); transition:stroke-dashoffset .4s ease; }
 .donut .pct{ font-weight:800; font-size:24px; text-anchor:middle; dominant-baseline:central; }
+
+/* 隐藏动画 canvas，避免占位撑开布局 */
+#ion-canvas{
+  display:none;
+  position:absolute;
+  top:0;
+  left:0;
+}


### PR DESCRIPTION
## Summary
- hide disintegration canvas by default so it no longer offsets the layout
- clean up markup by removing stray section close and wrapping done screen inside main container

## Testing
- `npm test` (fails: could not read package.json)
- `npm run lint` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a165a4abc08324b415ef02c846a4fc