### PR TITLE
feat: restructure homepage layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,13 +77,11 @@ function updateProgress(){
   }
 }
 
-// ====== 实时日期时钟 ======
-function pad(n){ return n.toString().padStart(2,'0'); }
+// ====== 实时时间 ======
 function tick(){
-  const d = new Date();
-  const str = `${d.getFullYear()}年${d.getMonth()+1}月${d.getDate()}日 ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  const str = new Date().toLocaleTimeString('zh-CN', { hour12: false });
   document.getElementById('now').textContent = str;
-  setTimeout(tick, 250);
+  setTimeout(tick, 1000);
 }
 
 // ====== 离子消除动画（简版粒子溶解） ======

--- a/index.html
+++ b/index.html
@@ -7,27 +7,19 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <div class="wrap" id="app">
+  <div class="app" id="app">
     <canvas id="ion-canvas"></canvas>
 
-    <div class="date-card" aria-live="polite">
-      <span id="now">——</span>
+    <div class="time-card" aria-live="polite">
+      <span id="now">--:--:--</span>
     </div>
 
-    
-    <div class="board card">
-      <div id="subjects"></div>
+    <div class="panel">
+      <div class="panel__title">作业</div>
+      <div class="panel__body" id="subjects"></div>
     </div>
 
-    <div class="donut" aria-label="进度甜甜圈">
-      <svg viewBox="0 0 140 140" role="img" aria-labelledby="donut-title">
-        <title id="donut-title">完成进度</title>
-        <circle class="track" cx="70" cy="70" r="60" stroke-width="12"></circle>
-        <circle class="ring" id="ring" cx="70" cy="70" r="60" stroke-width="12"
-                stroke-dasharray="377" stroke-dashoffset="377"></circle>
-        <text id="pctText" class="pct" x="70" y="76">0%</text>
-      </svg>
-    </div>
+    <button class="fab" aria-label="新增">+</button>
 
     <div class="done-screen" id="done">
       <div class="card">

--- a/styles.css
+++ b/styles.css
@@ -1,40 +1,69 @@
 /* ===== iOS 拟物，白色背景（无流动背景），删除线回调为半黑 ===== */
 :root{
   --bg:#f5f5f7;
-  --ink:#1d1d1f;
+  --text:#1d1d1f;
   --muted:#6e6e73;
-  --accent:#34c759;
   --border:#d2d2d7;
-  --strike: rgba(0,0,0,.55); /* 删除线半黑（回调） */
   --card:#ffffffee;
+  --accent:#34c759;
+  --strike: rgba(0,0,0,.55);
+  --radius:16px;
+  --shadow:0 6px 16px rgba(0,0,0,.06);
+  --gap:16px;
+  --maxw:480px;
+  --ink: var(--text);
 }
 
 @media (prefers-color-scheme: dark){
   :root{
     --bg:#0f1115;
-    --ink:#f2f2f7; --muted:#a1a1a6; --border:#2c2c2e;
-    --card:#0f1115e6; --strike:rgba(255,255,255,.5);
+    --text:#f2f2f7;
+    --muted:#a1a1a6;
+    --border:#2c2c2e;
+    --card:#0f1115e6;
+    --strike:rgba(255,255,255,.5);
   }
 }
 
 *{ box-sizing:border-box; }
 html, body{ height:100%; }
 body{
-  margin:0; color:var(--ink);
+  margin:0; color:var(--text);
   font:16px/1.6 -apple-system,BlinkMacSystemFont,"SF Pro Display","SF Pro Text",system-ui,"Helvetica Neue",Segoe UI,Arial;
   background: var(--bg);
   overflow-x:hidden;
 }
 
-.wrap{ min-height:100%; display:grid; place-items:center; padding:32px; }
+.app{ height:100dvh; display:grid; grid-template-rows:auto 1fr; gap:var(--gap);
+      padding:var(--gap) var(--gap) calc(96px + env(safe-area-inset-bottom));
+      max-width:var(--maxw); margin:0 auto; }
 
-/* 时间卡片（可留玻璃风格，也可换为纯白卡片） */
-.date-card{
-  background: #fff;
-  border:1px solid var(--border); border-radius:16px; padding:14px 18px;
-  box-shadow: 0 8px 18px rgba(0,0,0,.06), inset 0 1px 0 rgba(255,255,255,.7);
+/* 时间卡片 */
+.time-card{
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border:1px solid var(--border);
   display:flex; align-items:center; justify-content:center;
-  font-weight:700; letter-spacing:.5px; font-size:20px; color:var(--ink);
+  padding:var(--gap);
+  font-weight:700; text-align:center;
+}
+
+.panel{ background:var(--card); border-radius:var(--radius); box-shadow:var(--shadow);
+        display:flex; flex-direction:column; min-height:0; overflow:hidden; }
+.panel__title{ position:sticky; top:0; z-index:1; padding:var(--gap);
+              font-weight:700; border-bottom:1px solid var(--border); background:var(--card); }
+.panel__body{ flex:1; min-height:0; overflow-y:auto; scrollbar-gutter:stable; padding:var(--gap); }
+@supports not (scrollbar-gutter:stable){
+  .panel__body{ overflow-y:scroll; padding-right:calc(var(--gap) + 8px); }
+}
+.fab{ position:fixed; left:50%; transform:translateX(-50%);
+      bottom:calc(16px + env(safe-area-inset-bottom)); width:92px; height:92px; border-radius:50%;
+      background:var(--accent); color:#fff; border:none; box-shadow:var(--shadow); cursor:pointer;
+      display:flex; align-items:center; justify-content:center; font-size:32px; }
+
+@media (prefers-reduced-motion: reduce){
+  *{animation:none!important;transition:none!important;}
 }
 
 /* 内容布局 */


### PR DESCRIPTION
## Summary
- adopt CSS Grid layout with time card, scrollable homework panel, and centered FAB
- update time display to zh-CN 24-hour clock refreshed each second

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a17275b2b88324adc11acdf7dddc5c