### PR TITLE
feat: stable subject sorting with configurable animation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,8 @@
   --gap:16px;
   --maxw:480px;
   --ink: var(--text);
+  --move-dur:380ms;
+  --move-ease:cubic-bezier(.22,.61,.36,1);
 }
 
 @media (prefers-color-scheme: dark){
@@ -23,6 +25,10 @@
     --card:#0f1115e6;
     --strike:rgba(255,255,255,.5);
   }
+}
+
+@media (prefers-reduced-motion: reduce){
+  :root{ --move-dur:0ms; }
 }
 
 *{ box-sizing:border-box; }
@@ -57,6 +63,7 @@ body{
 @supports not (scrollbar-gutter:stable){
   .panel__body{ overflow-y:scroll; padding-right:calc(var(--gap) + 8px); }
 }
+#subjects.reordering{ pointer-events:none; }
 .donut{ position:fixed; left:50%; transform:translateX(-50%);
         bottom:calc(16px + env(safe-area-inset-bottom)); width:92px; height:92px;
         display:grid; place-items:center; }
@@ -83,8 +90,8 @@ body{
   border:1px solid var(--border); border-radius:18px;
   box-shadow: 0 6px 16px rgba(0,0,0,.06), inset 0 1px 0 rgba(255,255,255,.4);
   padding:14px 16px; margin-bottom:14px;
-  will-change:transform;
-  transition:transform 220ms cubic-bezier(0.2,0,0,1), opacity 220ms;
+  transition: transform var(--move-dur) var(--move-ease), opacity var(--move-dur) var(--move-ease);
+  will-change: transform;
 }
 .subject-title{ font-weight:700; font-size:18px; margin:2px 0 8px; letter-spacing:.2px; }
 .tasks{ margin:0; padding:0; list-style:none; }


### PR DESCRIPTION
## Summary
- slow and parametrize subject card move animation via CSS variables with reduced-motion fallback
- implement stable sorting with FLIP-based reordering so unchecked subjects return to their original spot

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a1797482908324a2d5a3558d8b9e57