### PR TITLE
feat: add WAAPI FLIP resort

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -12,7 +12,7 @@
   --gap:16px;
   --maxw:480px;
   --ink: var(--text);
-  --move-dur:380ms;
+  --move-dur:420ms;
   --move-ease:cubic-bezier(.22,.61,.36,1);
   --fade-dur:220ms;
 }
@@ -91,7 +91,7 @@ body{
   border:1px solid var(--border); border-radius:18px;
   box-shadow: 0 6px 16px rgba(0,0,0,.06), inset 0 1px 0 rgba(255,255,255,.4);
   padding:14px 16px; margin-bottom:14px;
-  transition: transform var(--move-dur) var(--move-ease), opacity var(--fade-dur) ease-out;
+  transition: opacity var(--fade-dur) ease-out;
   will-change: transform;
 }
 .subject-title{ font-weight:700; font-size:18px; margin:2px 0 8px; letter-spacing:.2px; }


### PR DESCRIPTION
## Summary
- use WAAPI-based FLIP animation for subject card resorting
- update motion variables and disable transform transition

## Testing
- `npm test` (fails: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a17ed2ffa88324a8e14e539a784366