### PR TITLE
feat: add iOS token and theme styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>作业预览 · 苹果拟物</title>
+  <link rel="stylesheet" href="/styles/tokens.css" />
+  <link rel="stylesheet" href="/styles/ios-theme.css" />
   <link rel="stylesheet" href="/css/base.css" />
   <link rel="stylesheet" href="/css/layout.css" />
   <link rel="stylesheet" href="/css/hw-panel.css" />

--- a/styles/ios-theme.css
+++ b/styles/ios-theme.css
@@ -1,0 +1,86 @@
+html {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, sans-serif;
+  background: var(--bg);
+  color: var(--label);
+  line-height: 1.5;
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--label);
+}
+
+* { box-sizing: border-box; }
+
+a { color: var(--tint); }
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: var(--label);
+  background: var(--fill);
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  transition: background var(--dur-fast) var(--ease-standard),
+    color var(--dur-fast) var(--ease-standard);
+}
+
+button:hover,
+input:hover,
+select:hover,
+textarea:hover {
+  background: color-mix(in srgb, var(--fill) 80%, var(--tint));
+}
+
+button:active {
+  transform: scale(0.98);
+  transition: transform var(--dur-fast) var(--ease-emphasized);
+}
+
+:focus-visible {
+  outline: 2px solid var(--tint);
+  outline-offset: 2px;
+}
+
+hr {
+  height: 1px;
+  border: 0;
+  background: var(--separator);
+  margin: 0;
+}
+
+.glass {
+  background: color-mix(in oklab, var(--surface) 60%, transparent);
+  backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid var(--separator);
+}
+
+.card {
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-1);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cell {
+  min-height: 44px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--separator);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,57 @@
+:root {
+  --bg: #f2f2f7;
+  --surface: #ffffff;
+  --elevated: #ffffff;
+  --label: #000000;
+  --secondary-label: #3c3c4399;
+  --tertiary-label: #3c3c434c;
+  --separator: #3c3c434a;
+  --fill: #78788029;
+  --tint: #007aff;
+
+  --radius-sm: 12px;
+  --radius-md: 16px;
+  --radius-lg: 20px;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+
+  --shadow-1: 0 1px 2px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.1);
+  --shadow-2: 0 4px 8px rgba(0,0,0,0.12), 0 2px 4px rgba(0,0,0,0.08);
+
+  --dur-fast: 120ms;
+  --dur-med: 200ms;
+  --dur-slow: 300ms;
+
+  --ease-standard: cubic-bezier(.2,.8,.2,1);
+  --ease-emphasized: cubic-bezier(.2,0,0,1);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #000000;
+    --surface: #1c1c1e;
+    --elevated: #2c2c2e;
+    --label: #ffffff;
+    --secondary-label: #ebebf599;
+    --tertiary-label: #ebebf54c;
+    --separator: #3c3c435a;
+    --fill: #ffffff1a;
+    --tint: #0a84ff;
+
+    --shadow-1: 0 1px 2px rgba(0,0,0,0.6), 0 1px 3px rgba(0,0,0,0.7);
+    --shadow-2: 0 4px 8px rgba(0,0,0,0.6), 0 2px 4px rgba(0,0,0,0.5);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --dur-fast: 0ms;
+    --dur-med: 0ms;
+    --dur-slow: 0ms;
+  }
+}


### PR DESCRIPTION
## Summary
- add design tokens for colors, spacing, radii, shadows, and motion
- apply global iOS-themed typography, components, and accessibility styles
- include new token and theme stylesheets in index.html

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1be98b0708324bbd6f1b10244f9de