### PR TITLE
feat: add iOS token and theme styles

### DIFF
--- a/css/hw-panel.css
+++ b/css/hw-panel.css
@@ -1,4 +1,5 @@
-.subject{
+.subject,
+#subjects > .card{
   background: #fff;
   border:1px solid var(--border); border-radius:18px;
   box-shadow: var(--shadow);
@@ -7,18 +8,20 @@
   will-change: transform;
 }
 .subject-title{ font-weight:700; font-size:18px; margin:2px 0 8px; letter-spacing:.2px; }
-.tasks{ margin:0; padding:0; list-style:none; }
+:is(.tasks, .list){ margin:0; padding:0; list-style:none; }
 @property --p{ syntax: '<number>'; initial-value: 0; inherits: false; }
-.task{ display:flex; align-items:center; gap:12px; padding:10px 6px; border-radius:12px; position:relative; }
-.task:hover{ background:linear-gradient(180deg, rgba(0,0,0,.04), transparent); }
-.task input{ position:absolute; opacity:0; pointer-events:none; }
-.checkbox{
+:is(.task, .cell){ display:flex; align-items:center; gap:12px; padding:10px 6px; border-radius:12px; position:relative; }
+:is(.task, .cell):hover{ background:linear-gradient(180deg, rgba(0,0,0,.04), transparent); }
+:is(.task, .cell) input{ position:absolute; opacity:0; pointer-events:none; }
+.checkbox,
+.switch{
   width:22px; height:22px; border-radius:8px; border:1px solid var(--border);
   background:linear-gradient(180deg,#fff,#f3f4f6);
   box-shadow:inset 0 1px 0 rgba(255,255,255,.8);
   display:inline-grid; place-items:center; flex:0 0 22px; position:relative; overflow:hidden;
 }
-.checkbox::after{
+.checkbox::after,
+.switch::after{
   content:""; position:absolute; left:5px; top:11px; width:12px; height:6px;
   border-left:3px solid var(--accent); border-bottom:3px solid var(--accent);
   transform: rotate(-45deg) scale(0); transform-origin: left bottom;
@@ -39,6 +42,6 @@
   content:""; position:absolute; left:0; right:0; top:50%; height:2px; border-radius:2px; background:var(--strike);
   transform: translateY(-50%) scaleX(var(--p)); transform-origin: left center; transition: transform .42s ease;
 }
-.task input:checked ~ .checkbox::after{ transform: rotate(-45deg) scale(1); }
-.task input:checked ~ .text{ --p: 1; }
-.task input:not(:checked) ~ .text{ --p: 0; }
+:is(.task, .cell) input:checked ~ :is(.checkbox, .switch)::after{ transform: rotate(-45deg) scale(1); }
+:is(.task, .cell) input:checked ~ .text{ --p: 1; }
+:is(.task, .cell) input:not(:checked) ~ .text{ --p: 0; }

--- a/css/layout.css
+++ b/css/layout.css
@@ -1,7 +1,7 @@
 .app{ height:100dvh; display:grid; grid-template-rows:auto 1fr; gap:var(--gap);
       padding:var(--gap) var(--gap) calc(96px + env(safe-area-inset-bottom));
       max-width:var(--maxw); margin:0 auto; }
-.time-card{
+.card.time-card{
   background: var(--card);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
@@ -10,15 +10,15 @@
   padding:var(--gap);
   font-weight:700; text-align:center;
 }
-.panel{ background:var(--card); border-radius:var(--radius); box-shadow:var(--shadow);
+.card.panel{ background:var(--card); border-radius:var(--radius); box-shadow:var(--shadow);
         display:flex; flex-direction:column; min-height:0; overflow:hidden; }
 .panel__body{ flex:1; min-height:0; overflow-y:auto; scrollbar-gutter:stable; padding:var(--gap); }
 @supports not (scrollbar-gutter:stable){
   .panel__body{ overflow-y:scroll; padding-right:calc(var(--gap) + 8px); }
 }
 #ion-canvas{ display:none; position:absolute; top:0; left:0; pointer-events:none; width:100%; height:100%; }
-.done-screen{ position:absolute; inset:0; display:none; align-items:center; justify-content:center; text-align:center; padding:24px; }
-.show-done .done-screen{ display:flex; }
-.done-screen .card{ background:#fff; border:1px solid var(--border); border-radius:22px; padding:28px 22px; box-shadow:0 12px 26px rgba(0,0,0,.12), inset 0 1px 0 rgba(255,255,255,.5); }
-.done-screen h1{ margin:0 0 6px; font-size:22px; }
-.done-screen p{ margin:0; color:var(--muted); }
+.modal.done-screen{ position:absolute; inset:0; display:none; align-items:center; justify-content:center; text-align:center; padding:24px; }
+.show-done .modal{ display:flex; }
+.modal .card{ background:#fff; border:1px solid var(--border); border-radius:22px; padding:28px 22px; box-shadow:0 12px 26px rgba(0,0,0,.12), inset 0 1px 0 rgba(255,255,255,.5); }
+.modal h1{ margin:0 0 6px; font-size:22px; }
+.modal p{ margin:0; color:var(--muted); }

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>作业预览 · 苹果拟物</title>
+  <link rel="stylesheet" href="/styles/tokens.css" />
+  <link rel="stylesheet" href="/styles/ios-theme.css" />
   <link rel="stylesheet" href="/css/base.css" />
   <link rel="stylesheet" href="/css/layout.css" />
   <link rel="stylesheet" href="/css/hw-panel.css" />
@@ -12,10 +14,10 @@
 <body>
   <div class="app" id="app">
     <canvas id="ion-canvas"></canvas>
-    <div class="time-card" aria-live="polite">
+    <div class="card time-card" aria-live="polite">
       <span id="now">--:--:--</span>
     </div>
-    <div class="panel">
+    <div class="card panel">
       <div class="panel__body" id="subjects"></div>
     </div>
     <figure class="donut" role="progressbar" aria-label="整体完成度" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
@@ -25,7 +27,7 @@
       </svg>
       <figcaption id="pctText" aria-live="polite">0%</figcaption>
     </figure>
-    <div class="done-screen" id="done">
+    <div class="modal done-screen" id="done">
       <div class="card">
         <h1>今日任务已完成</h1>
         <p>请好好休息。</p>

--- a/styles/ios-theme.css
+++ b/styles/ios-theme.css
@@ -1,0 +1,86 @@
+html {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, sans-serif;
+  background: var(--bg);
+  color: var(--label);
+  line-height: 1.5;
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--label);
+}
+
+* { box-sizing: border-box; }
+
+a { color: var(--tint); }
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: var(--label);
+  background: var(--fill);
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  transition: background var(--dur-fast) var(--ease-standard),
+    color var(--dur-fast) var(--ease-standard);
+}
+
+button:hover,
+input:hover,
+select:hover,
+textarea:hover {
+  background: color-mix(in srgb, var(--fill) 80%, var(--tint));
+}
+
+button:active {
+  transform: scale(0.98);
+  transition: transform var(--dur-fast) var(--ease-emphasized);
+}
+
+:focus-visible {
+  outline: 2px solid var(--tint);
+  outline-offset: 2px;
+}
+
+hr {
+  height: 1px;
+  border: 0;
+  background: var(--separator);
+  margin: 0;
+}
+
+.glass {
+  background: color-mix(in oklab, var(--surface) 60%, transparent);
+  backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid var(--separator);
+}
+
+.card {
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-1);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cell {
+  min-height: 44px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--separator);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,57 @@
+:root {
+  --bg: #f2f2f7;
+  --surface: #ffffff;
+  --elevated: #ffffff;
+  --label: #000000;
+  --secondary-label: #3c3c4399;
+  --tertiary-label: #3c3c434c;
+  --separator: #3c3c434a;
+  --fill: #78788029;
+  --tint: #007aff;
+
+  --radius-sm: 12px;
+  --radius-md: 16px;
+  --radius-lg: 20px;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+
+  --shadow-1: 0 1px 2px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.1);
+  --shadow-2: 0 4px 8px rgba(0,0,0,0.12), 0 2px 4px rgba(0,0,0,0.08);
+
+  --dur-fast: 120ms;
+  --dur-med: 200ms;
+  --dur-slow: 300ms;
+
+  --ease-standard: cubic-bezier(.2,.8,.2,1);
+  --ease-emphasized: cubic-bezier(.2,0,0,1);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #000000;
+    --surface: #1c1c1e;
+    --elevated: #2c2c2e;
+    --label: #ffffff;
+    --secondary-label: #ebebf599;
+    --tertiary-label: #ebebf54c;
+    --separator: #3c3c435a;
+    --fill: #ffffff1a;
+    --tint: #0a84ff;
+
+    --shadow-1: 0 1px 2px rgba(0,0,0,0.6), 0 1px 3px rgba(0,0,0,0.7);
+    --shadow-2: 0 4px 8px rgba(0,0,0,0.6), 0 2px 4px rgba(0,0,0,0.5);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --dur-fast: 0ms;
+    --dur-med: 0ms;
+    --dur-slow: 0ms;
+  }
+}


### PR DESCRIPTION
## Summary
- add design tokens for colors, spacing, radii, shadows, and motion
- apply global iOS-themed typography, components, and accessibility styles
- map existing layout classes to card, list, cell, modal, and switch hooks

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1be98b0708324bbd6f1b10244f9de