### PR TITLE
feat: smooth card reorder and stable strike

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       </div>
     </div>
   </div>
+  <script defer src="scripts/flip.js"></script>
   <script type="module" src="/src/app.js"></script>
 </body>
 </html>

--- a/scripts/flip.js
+++ b/scripts/flip.js
@@ -1,0 +1,48 @@
+export function flipReorder(container, itemSelector, mutateDOM, {
+  duration = 300,
+  easing = 'cubic-bezier(.2,.8,.2,1)',
+  stagger = 0
+} = {}) {
+  const items = Array.from(container.querySelectorAll(itemSelector));
+  if (!items.length) return;
+
+  const reduce = window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const first = new Map(items.map(el => [el, el.getBoundingClientRect()]));
+
+  mutateDOM(); // 在这里进行 append/insertBefore 等 DOM 顺序变更
+
+  const last = new Map(items.map(el => [el, el.getBoundingClientRect()]));
+
+  if (reduce) return;
+
+  items.forEach((el, i) => {
+    const f = first.get(el), l = last.get(el);
+    if (!f || !l) return;
+    const dx = f.left - l.left, dy = f.top - l.top;
+    if (dx || dy) {
+      el.animate(
+        [{ transform: `translate(${dx}px, ${dy}px)` }, { transform: 'translate(0,0)' }],
+        { duration, easing, fill: 'both', delay: i * stagger }
+      );
+    }
+  });
+}
+
+export function animateAutoHeight(el, d = 200, e = 'cubic-bezier(.2,.8,.2,1)'){
+  const reduce = window.matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const from = el.offsetHeight;
+  el.style.height = 'auto';
+  const to = el.offsetHeight;
+  el.style.height = from + 'px';
+  if (reduce) {
+    el.style.height = 'auto';
+    return;
+  }
+  el.offsetHeight;
+  el.style.transition = `height ${d}ms ${e}`;
+  el.style.height = to + 'px';
+  el.addEventListener('transitionend', () => {
+    el.style.height = 'auto';
+    el.style.transition = '';
+  }, { once: true });
+}

--- a/src/hw-panel/index.js
+++ b/src/hw-panel/index.js
@@ -1,6 +1,6 @@
 import { render, updateCompletion } from './render.js';
-import { reorder } from '../anim/flip.js';
 import { debounce } from '../utils/dom.js';
+import { flipReorder, animateAutoHeight } from '/scripts/flip.js';
 import { state, getState, setState, addSubject as add, removeSubject as remove, updateTask } from './state.js';
 import { sortByCompleteThenSeq } from './sort.js';
 import { selectProgress } from './state.js';
@@ -10,8 +10,11 @@ export function initHwPanel({ mount, onProgress }) {
   updateCompletion(mount, state);
   onProgress(selectProgress());
   const debounced = debounce(() => {
-    const items = Array.from(mount.children);
-    reorder(items, mount, sortByCompleteThenSeq);
+    animateAutoHeight(mount, 180);
+    flipReorder(mount, '.card', () => {
+      const items = Array.from(mount.children).sort(sortByCompleteThenSeq);
+      items.forEach(el => mount.appendChild(el));
+    }, { duration: 300, easing: 'cubic-bezier(.2,.8,.2,1)', stagger: 24 });
   }, 100);
   mount.addEventListener('change', e => {
     const input = e.target;

--- a/src/hw-panel/render.js
+++ b/src/hw-panel/render.js
@@ -5,7 +5,7 @@ export function render(mount, state) {
   const frag = document.createDocumentFragment();
   state.forEach(subj => {
     const card = document.createElement('div');
-    card.className = 'subject';
+    card.className = 'subject card';
     card.dataset.id = subj.id;
     card.dataset.seq = String(subj.seq);
     const title = document.createElement('div');

--- a/styles/ios-theme.css
+++ b/styles/ios-theme.css
@@ -84,3 +84,40 @@ hr {
     transition: none !important;
   }
 }
+
+/* === Strikethrough anti-flicker (composite-only) === */
+.task .text{
+  position: relative;
+  display: inline-block;
+  color: var(--label);
+  background: none;
+  -webkit-background-clip: border-box;
+  background-clip: border-box;
+  transition: color var(--dur-med) var(--ease-standard);
+  will-change: color;
+}
+.task .text::after{
+  content: "";
+  position: absolute;
+  left: 0; right: 0;
+  top: 0.58em;
+  height: 1px;
+  background: var(--strike-color, rgba(0,0,0,.5));
+  transform-origin: left center;
+  transform: scaleX(0) translateZ(0);
+  transition: transform var(--dur-med) var(--ease-standard);
+  will-change: transform;
+  pointer-events: none;
+  contain: paint;
+}
+/* 选中态：线展开 + 文本降权 */
+.task input[type="checkbox"]:checked + .checkbox + .text{
+  color: var(--secondary-label);
+}
+.task input[type="checkbox"]:checked + .checkbox + .text::after{
+  transform: scaleX(1) translateZ(0);
+}
+@media (prefers-reduced-motion: reduce){
+  .task .text{ transition: none; }
+  .task .text::after{ transition: none; }
+}


### PR DESCRIPTION
## Summary
- prevent strike-through flicker with pseudo-element transform
- animate subject card reordering using FLIP with optional auto-height

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1c6f500c88324a877e74ca9cf95e3