### PR TITLE
fix(homework): hide progress ring in two-column mode, harden CSV parsing, and add cache-busting

### DIFF
--- a/scripts/homework.js
+++ b/scripts/homework.js
@@ -1,75 +1,117 @@
-async function loadHomework() {
-  let root = document.getElementById('homework-root');
-  if (!root) root = document.getElementById('subjects-root');
-  if (!root) {
-    root = document.createElement('div');
-    root.id = 'homework-root';
-    const panel = document.querySelector('.panel__body') || document.body;
-    panel.appendChild(root);
-  }
-  const parent = root.parentElement;
-  if (parent && parent.id === 'subjects') {
-    parent.innerHTML = '';
-    parent.appendChild(root);
-  }
-  const res = await fetch('/data/homework.csv');
-  const text = await res.text();
-  const records = parseCSV(text);
-  const groups = [];
-  for (const { subject, task } of records) {
-    let g = groups.find(s => s.subject === subject);
-    if (!g) {
-      g = { subject, tasks: [] };
-      groups.push(g);
-    }
-    g.tasks.push(task);
-  }
-  groups.forEach(g => {
-    const card = document.createElement('div');
-    card.className = 'subject-card';
-    const title = document.createElement('h2');
-    title.textContent = g.subject;
-    card.appendChild(title);
-    const ul = document.createElement('ul');
-    g.tasks.forEach(t => {
-      const li = document.createElement('li');
-      li.className = 'task-item';
-      li.textContent = t;
-      ul.appendChild(li);
-    });
-    card.appendChild(ul);
-    root.appendChild(card);
-  });
-}
+(() => {
+  const CSV_URL = `/data/homework.csv?ts=${Date.now()}`;
 
-function parseCSV(text) {
-  const lines = text.trim().split(/\r?\n/);
-  const out = [];
-  for (let i = 1; i < lines.length; i++) {
-    const line = lines[i];
-    const cells = [];
-    let cur = '';
-    let inQuotes = false;
-    for (let j = 0; j < line.length; j++) {
-      const ch = line[j];
+  function parseCSV(text) {
+    // 去 BOM、统一换行
+    if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1);
+    text = text.replace(/\r\n?/g, '\n');
+
+    // 简易 CSV 解析（支持引号与逗号）
+    const rows = [];
+    let cur = '', inQuotes = false, row = [];
+    for (let i = 0; i < text.length; i++) {
+      const ch = text[i], next = text[i + 1];
       if (ch === '"') {
-        if (inQuotes && line[j + 1] === '"') {
-          cur += '"';
-          j++;
-        } else {
-          inQuotes = !inQuotes;
-        }
+        if (inQuotes && next === '"') { cur += '"'; i++; }
+        else inQuotes = !inQuotes;
       } else if (ch === ',' && !inQuotes) {
-        cells.push(cur);
-        cur = '';
+        row.push(cur); cur = '';
+      } else if (ch === '\n' && !inQuotes) {
+        row.push(cur); cur = '';
+        if (row.some(cell => cell.trim() !== '')) rows.push(row);
+        row = [];
       } else {
         cur += ch;
       }
     }
-    cells.push(cur);
-    out.push({ subject: cells[0].trim(), task: cells[1].trim() });
-  }
-  return out;
-}
+    if (cur.length || row.length) { row.push(cur); if (row.some(c => c.trim() !== '')) rows.push(row); }
 
-document.addEventListener('DOMContentLoaded', loadHomework);
+    if (!rows.length) return { header: [], data: [] };
+    const header = rows[0].map(h => h.trim());
+    const data = rows.slice(1).map(r => {
+      const obj = {};
+      header.forEach((h, idx) => obj[h] = (r[idx] ?? '').trim());
+      return obj;
+    });
+    return { header, data };
+  }
+
+  function ensureContainer() {
+    let el = document.querySelector('#homework-root') || document.querySelector('#subjects-root');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'homework-root';
+      const main = document.querySelector('main') || document.body;
+      main.appendChild(el);
+    }
+    return el;
+  }
+
+  function render({ header, data }) {
+    const root = ensureContainer();
+    root.innerHTML = '';
+
+    // 分组：按出现顺序
+    const groups = [];
+    const map = new Map();
+    for (const rec of data) {
+      const subject = (rec.subject || '').trim();
+      const task = (rec.task || '').trim();
+      if (!subject && !task) continue;
+      if (!map.has(subject)) { map.set(subject, { subject, items: [] }); groups.push(map.get(subject)); }
+      map.get(subject).items.push(task);
+    }
+
+    for (const g of groups) {
+      const card = document.createElement('section');
+      card.className = 'subject-card';
+      card.innerHTML = `
+        <h2 class="subject-title">${g.subject || '未命名学科'}</h2>
+        <ul class="task-list">
+          ${g.items.map(t => `<li class="task-item">${t}</li>`).join('')}
+        </ul>
+      `;
+      root.appendChild(card);
+    }
+
+    // —— 进度环逻辑：两列模式无完成状态 → 隐藏环
+    const ring = document.querySelector('[data-role="progress-ring"]') || document.querySelector('#progress-ring');
+    if (ring) {
+      const hasDoneColumn = header.map(h => h.toLowerCase()).includes('done');
+      if (!hasDoneColumn) {
+        ring.style.display = 'none';
+      } else {
+        // 兼容旧站：若存在 done 列则计算百分比
+        const total = data.length || 0;
+        const done = data.filter(r => String(r.done).trim() === '1' || String(r.done).toLowerCase() === 'true').length;
+        const pct = total ? Math.round((done / total) * 100) : 0;
+        const label = ring.querySelector('[data-role="progress-label"]') || ring;
+        label.textContent = `${pct}%`;
+      }
+    }
+  }
+
+  async function boot() {
+    try {
+      const res = await fetch(CSV_URL, { cache: 'no-store' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const text = await res.text();
+      const parsed = parseCSV(text);
+      render(parsed);
+    } catch (err) {
+      console.warn('[homework] load failed:', err);
+      const root = ensureContainer();
+      root.innerHTML = `<div class="hw-error">加载作业数据失败，请稍后刷新。</div>`;
+      const ring = document.querySelector('[data-role="progress-ring"]') || document.querySelector('#progress-ring');
+      if (ring) ring.style.display = 'none';
+    }
+  }
+
+  // 延后到空闲或 DOMReady
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    (window.requestIdleCallback || setTimeout)(boot, 0);
+  }
+})();
+

--- a/styles/base.css
+++ b/styles/base.css
@@ -5,3 +5,10 @@
 .task-item {
   margin-left: 1.25rem;
 }
+
+/* homework minimal styles */
+.subject-card { background: #fff; border-radius: 16px; padding: 16px 20px; box-shadow: 0 4px 16px rgba(0,0,0,.06); margin: 16px 12px; }
+.subject-title { margin: 0 0 8px; font-size: 20px; font-weight: 700; color: #1d1d1f; }
+.task-list { margin: 0; padding-left: 1.2em; color: #1d1d1f; }
+.task-item { margin: 4px 0; list-style: disc; }
+.hw-error { color: #d00; padding: 12px 16px; background: #fff3f3; border-radius: 12px; margin: 12px; }


### PR DESCRIPTION
## Summary
- replace homework loader with BOM-safe CSV parser, cache-busting and progress ring visibility
- append minimal homework card styles

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1dacce5ec83248c085316b6f0fb7e