### PR TITLE
fix(homework): remove legacy subjects view, guard against double init, and hard-hide duplicates

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,9 @@
       <span id="now">--:--:--</span>
     </div>
       <div class="card panel">
-        <div class="panel__body" id="subjects"><div id="homework-root"></div></div>
+        <div class="panel__body">
+          <div id="homework-root"></div>
+        </div>
       </div>
       <figure id="progress-ring" class="donut" role="progressbar" aria-label="整体完成度" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
       <svg viewBox="0 0 92 92">

--- a/scripts/homework.js
+++ b/scripts/homework.js
@@ -1,19 +1,29 @@
 (() => {
+  if (window.__HW_BOOTED__) return; // 一次性守卫（防重复）
+  window.__HW_BOOTED__ = true;
+
   const CSV_URL = `/data/homework.csv?ts=${Date.now()}`;
+  const LEGACY_SEL = [
+    '#subjects-root',
+    '[data-role="subjects"]',
+    '.subjects',
+    '.subject-list',
+    '.subject-card'
+  ].join(',');
 
   function parseCSV(text) {
     if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1);
     text = text.replace(/\r\n?/g, '\n');
-    const rows = []; let cur = '', inQ = false, row = [];
-    for (let i = 0; i < text.length; i++) {
-      const ch = text[i], nx = text[i+1];
-      if (ch === '"') { if (inQ && nx === '"') { cur += '"'; i++; } else inQ = !inQ; }
-      else if (ch === ',' && !inQ) { row.push(cur); cur=''; }
-      else if (ch === '\n' && !inQ) { row.push(cur); if (row.some(c=>c.trim()!=='')) rows.push(row); cur=''; row=[]; }
+    const rows = []; let cur='', inQ=false, row=[];
+    for (let i=0;i<text.length;i++){
+      const ch=text[i], nx=text[i+1];
+      if (ch === '"'){ if(inQ && nx === '"'){cur+='"'; i++;} else inQ=!inQ; }
+      else if (ch === ',' && !inQ){ row.push(cur); cur=''; }
+      else if (ch === '\n' && !inQ){ row.push(cur); if(row.some(c=>c.trim()!=='')) rows.push(row); cur=''; row=[]; }
       else cur += ch;
     }
-    if (cur.length || row.length) { row.push(cur); if (row.some(c=>c.trim()!=='')) rows.push(row); }
-    if (!rows.length) return { header: [], data: [] };
+    if (cur.length || row.length){ row.push(cur); if(row.some(c=>c.trim()!=='')) rows.push(row); }
+    if (!rows.length) return { header:[], data:[] };
     const header = rows[0].map(h=>h.trim());
     const data = rows.slice(1).map(r => {
       const o={}; header.forEach((h,i)=>o[h]=(r[i]??'').trim()); return o;
@@ -26,33 +36,34 @@
     if (!root) {
       root = document.createElement('div');
       root.id = 'homework-root';
-      const main = document.querySelector('main') || document.body;
-      main.appendChild(root);
+      (document.querySelector('main') || document.body).appendChild(root);
     }
-    // 隐藏旧容器，避免重复（若存在）
-    const legacy = document.querySelector('#subjects-root');
-    if (legacy && legacy !== root) legacy.style.display = 'none';
     return root;
   }
 
-  function dedupeProgressRing() {
-    const rings = Array.from(document.querySelectorAll('[data-role="progress-ring"], #progress-ring'));
-    if (!rings.length) return;
-    const first = rings[0];
-    // 把第一个移到 body 末尾，设为固定定位；其余移除
-    document.body.appendChild(first);
-    first.style.position = 'fixed';
-    first.style.left = '50%';
-    first.style.bottom = '24px';
-    first.style.transform = 'translateX(-50%)';
-    for (let i = 1; i < rings.length; i++) rings[i].remove();
+  function killLegacyOnce() {
+    // 样式级隐藏（全局开关）
+    document.body.setAttribute('data-hide-legacy-subjects', '1');
+    // DOM 级移除：凡匹配旧选择器且不在 #homework-root 内的，一律移除
+    const root = document.querySelector('#homework-root');
+    document.querySelectorAll(LEGACY_SEL).forEach(el => {
+      if (!root || !root.contains(el)) el.remove();
+    });
+  }
+
+  function observeAndKillLegacy() {
+    const root = document.querySelector('#homework-root');
+    const mo = new MutationObserver(() => {
+      document.querySelectorAll(LEGACY_SEL).forEach(el => {
+        if (!root || !root.contains(el)) el.remove();
+      });
+    });
+    mo.observe(document.body, { childList: true, subtree: true });
   }
 
   function render({ data }) {
     const root = ensureRoot();
     root.innerHTML = '';
-    root.setAttribute('data-hw-root', '1');
-
     // 分组（按出现顺序）
     const groups = [];
     const map = new Map();
@@ -63,7 +74,6 @@
       if (!map.has(s)) { map.set(s, {subject:s, items:[]}); groups.push(map.get(s)); }
       map.get(s).items.push(t);
     }
-
     for (const g of groups) {
       const card = document.createElement('section');
       card.className = 'hw-card';
@@ -71,26 +81,37 @@
         <h2 class="hw-title">${g.subject || '未命名学科'}</h2>
         <ul class="hw-list">
           ${g.items.map(t => `<li class="hw-item">${t}</li>`).join('')}
-        </ul>
-      `;
+        </ul>`;
       root.appendChild(card);
     }
-
-    dedupeProgressRing();
   }
 
   async function boot() {
     try {
+      killLegacyOnce();
+      observeAndKillLegacy();
+
       const res = await fetch(CSV_URL, { cache: 'no-store' });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const text = await res.text();
       const parsed = parseCSV(text);
       render(parsed);
+
+      // 进度环若有多个，仅保留一个并固定到底部中央
+      const rings = Array.from(document.querySelectorAll('[data-role="progress-ring"], #progress-ring'));
+      if (rings.length) {
+        const first = rings[0];
+        document.body.appendChild(first);
+        first.style.position = 'fixed';
+        first.style.left = '50%';
+        first.style.bottom = '24px';
+        first.style.transform = 'translateX(-50%)';
+        for (let i = 1; i < rings.length; i++) rings[i].remove();
+      }
     } catch (e) {
-      console.warn('[homework] load failed', e);
+      console.warn('[homework] boot failed:', e);
       const root = ensureRoot();
       root.innerHTML = `<div class="hw-error">加载作业数据失败，请稍后刷新。</div>`;
-      dedupeProgressRing();
     }
   }
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -22,3 +22,19 @@
 /* 如果旧样式仍在，避免误命中（保险条款） */
 #homework-root .task-item::before,
 #homework-root .task-item::after { content:none !important; display:none !important; }
+/* homework namespace */
+#homework-root { padding: 0 8px 96px; }
+.hw-card { background:#fff; border-radius:16px; padding:16px 20px; box-shadow:0 4px 16px rgba(0,0,0,.06); margin:16px 12px; }
+.hw-title { margin:0 0 8px; font-size:20px; font-weight:700; color:#1d1d1f; }
+.hw-list { margin:0; padding-left:1.2em; color:#1d1d1f; }
+.hw-item { margin:6px 0; list-style: disc; }
+.hw-error { color:#d00; padding:12px 16px; background:#fff3f3; border-radius:12px; margin:12px; }
+
+/* 一键隐藏旧视图（不影响 #homework-root 内部） */
+[data-hide-legacy-subjects] .subject-card,
+[data-hide-legacy-subjects] #subjects-root,
+[data-hide-legacy-subjects] [data-role="subjects"],
+[data-hide-legacy-subjects] .subjects,
+[data-hide-legacy-subjects] .subject-list {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- remove legacy subject container and only mount #homework-root
- harden homework.js with double-init guard and legacy DOM killers
- hide legacy subject blocks via global CSS toggle

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1e14df2c88324b57152a8c37e76bf