### PR TITLE
fix(ui): restore clock card, bring back strikethrough transition, FLIP reorder for done/undo, and keep animated donut

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="/styles/base.css" />
 </head>
 <body>
+  <div id="clock-root"></div>
   <div id="homework-root"></div>
   <script src="/scripts/homework.js"></script>
 </body>

--- a/scripts/homework.js
+++ b/scripts/homework.js
@@ -5,40 +5,46 @@
   const LS_KEY  = 'hw:done:v1';
   let prevPct = 0;
 
-  // —— 小工具
-  const raf = (fn)=> (window.requestAnimationFrame||setTimeout)(fn,0);
-  function animateNumber(el, from, to, ms=400){
-    const t0 = performance.now();
-    const step = (now)=>{
-      const p = Math.min(1, (now - t0) / ms);
-      const v = Math.round(from + (to - from) * p);
-      el.textContent = `${v}%`;
-      if (p < 1) requestAnimationFrame(step);
-    };
-    requestAnimationFrame(step);
+  // —— 工具
+  function byId(id){ return document.getElementById(id); }
+  // eslint-disable-next-line no-unused-vars
+  function ensure(el, tag='div'){ return el || document.createElement(tag); }
+  function format(ts=new Date()){
+    const d = ts;
+    return `${d.getFullYear()}/${d.getMonth()+1}/${d.getDate()} ${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}:${String(d.getSeconds()).padStart(2,'0')}`;
   }
-  function animateRing(fromPct, toPct, ms=400){
+  function animateNumber(el, from, to, ms=380){
     const t0 = performance.now();
-    const shell = ensureRing().querySelector('.hw-ring');
     const tick = (now)=>{
       const p = Math.min(1,(now-t0)/ms);
-      const deg = (fromPct + (toPct - fromPct)*p) * 3.6;
-      shell.style.background = `conic-gradient(#22c55e ${deg}deg, #e5e7eb 0deg)`;
+      const v = Math.round(from + (to-from)*p);
+      el.textContent = `${v}%`;
+      if (p < 1) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  }
+  function animateRing(fromPct, toPct, ms=380){
+    const ring = ensureRing().querySelector('.hw-ring');
+    const t0 = performance.now();
+    const tick = (now)=>{
+      const p = Math.min(1,(now-t0)/ms);
+      const deg = (fromPct + (toPct-fromPct)*p) * 3.6;
+      ring.style.background = `conic-gradient(#22c55e ${deg}deg, #e5e7eb 0deg)`;
       if (p < 1) requestAnimationFrame(tick);
     };
     requestAnimationFrame(tick);
   }
 
   // —— 存取
-  function loadDone(){ try{ return JSON.parse(localStorage.getItem(LS_KEY)||'{}'); }catch{ return {}; } }
-  function saveDone(m){ try{ localStorage.setItem(LS_KEY, JSON.stringify(m)); }catch{ /* ignore */ } }
   function idOf(subject, task){
     const s = `${subject}||${task}`; let h = 2166136261;
     for (let i=0;i<s.length;i++){ h ^= s.charCodeAt(i); h = (h * 16777619) >>> 0; }
     return h.toString(36);
   }
+  function loadDone(){ try{ return JSON.parse(localStorage.getItem(LS_KEY)||'{}'); }catch{ return {}; } }
+  function saveDone(m){ try{ localStorage.setItem(LS_KEY, JSON.stringify(m)); }catch{ /* ignore */ } }
 
-  // —— CSV 解析（两列）
+  // —— CSV 两列解析
   function parseCSV(text){
     if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1);
     text = text.replace(/\r\n?/g,'\n');
@@ -55,25 +61,34 @@
     if(!rows.length) return [];
     const header = rows[0].map(h=>h.trim().toLowerCase());
     const sIdx = header.indexOf('subject'), tIdx = header.indexOf('task');
-    return rows.slice(1).map(r => ({ subject:(r[sIdx]||'').trim(), task:(r[tIdx]||'').trim() }));
+    return rows.slice(1).map((r, idx) => ({ subject:(r[sIdx]||'').trim(), task:(r[tIdx]||'').trim(), idx }));
   }
 
-  function ensureRoot(){
-    let root = document.querySelector('#homework-root');
-    if(!root){ root = document.createElement('div'); root.id='homework-root'; (document.querySelector('main')||document.body).appendChild(root); }
-    const legacy = document.querySelector('#subjects-root'); if (legacy && legacy!==root) legacy.style.display='none';
-    return root;
+  // —— 时间卡片
+  function ensureClock(){
+    let host = byId('clock-root');
+    if (!host){
+      host = document.createElement('div');
+      host.id = 'clock-root';
+      (document.querySelector('main')||document.body).prepend(host);
+    }
+    host.innerHTML = `<div class="clock-card" id="clock-card"></div>`;
+    const card = byId('clock-card');
+    const tick = () => { card.textContent = format(new Date()); };
+    tick();
+    clearInterval(window.__HW_CLOCK_TMR__);
+    window.__HW_CLOCK_TMR__ = setInterval(tick, 1000);
   }
+
+  // —— 进度环
   function ensureRing(){
     let ring = document.querySelector('[data-role="progress-ring"]') || document.querySelector('#progress-ring');
     if(!ring){
       ring = document.createElement('div');
       ring.id='progress-ring'; ring.setAttribute('data-role','progress-ring');
       ring.innerHTML = `<div class="hw-ring"></div><div class="hw-ring-label" data-role="progress-label">0%</div>`;
-      document.body.appendChild(ring);
-    } else {
-      document.body.appendChild(ring);
     }
+    document.body.appendChild(ring);
     Object.assign(ring.style,{position:'fixed',left:'50%',bottom:'24px',transform:'translateX(-50%)',zIndex:'999'});
     return ring;
   }
@@ -86,65 +101,59 @@
     prevPct = pct;
   }
 
-  // —— FLIP 排序动画（置底/回原位）
-  function flipReorder(list){
-    const items = Array.from(list.children);
-    const first = new Map(items.map(el => [el, el.getBoundingClientRect()]));
-    items.forEach(el => el.classList.add('hw-moving'));
-    raf(() => {
-      items.forEach(el=>{
+  // —— FLIP 排序：已完成置底，取消回原位（按 idx）
+  function reorderWithFLIP(list, comparator){
+    const children = Array.from(list.children);
+    const first = new Map(children.map(el => [el, el.getBoundingClientRect()]));
+    // 变更 DOM 顺序
+    const sorted = Array.from(children).sort(comparator);
+    sorted.forEach(el => list.appendChild(el));
+    // 计算最后位置并反向位移
+    requestAnimationFrame(()=>{
+      sorted.forEach(el=>{
         const last = el.getBoundingClientRect();
-        const dx = first.get(el).left - last.left;
-        const dy = first.get(el).top  - last.top;
-        el.style.transform = `translate(${dx}px, ${dy}px)`;
+        const invX = first.get(el).left - last.left;
+        const invY = first.get(el).top  - last.top;
+        el.style.transform = `translate(${invX}px, ${invY}px)`;
       });
-      // 两帧后回归原位触发过渡
-      requestAnimationFrame(()=>requestAnimationFrame(()=>{
-        items.forEach(el=>{ el.style.transform='translate(0,0)'; });
-        const onEnd = (e)=>{ if(e.propertyName!=='transform') return; e.currentTarget.classList.remove('hw-moving'); e.currentTarget.removeEventListener('transitionend', onEnd); };
-        items.forEach(el=> el.addEventListener('transitionend', onEnd));
-      }));
+      // 下一帧回归->触发过渡
+      requestAnimationFrame(()=> sorted.forEach(el=> el.style.transform = 'translate(0,0)'));
     });
   }
 
-  function resort(list){
-    const rows = Array.from(list.children);
-    rows.sort((a,b)=>{
-      const ad = a.classList.contains('hw-done') ? 1 : 0;
-      const bd = b.classList.contains('hw-done') ? 1 : 0;
-      if (ad !== bd) return ad - bd;            // 未完成在上；已完成置底
-      return (+a.dataset.idx) - (+b.dataset.idx); // 同组按原始顺序
-    });
-    const before = Array.from(list.children);
-    rows.forEach(el => list.appendChild(el));
-    if (before.some((el,i)=>el!==list.children[i])) flipReorder(list);
+  // —— 视图渲染
+  function ensureRoot(){
+    let root = document.querySelector('#homework-root');
+    if(!root){ root = document.createElement('div'); root.id='homework-root'; (document.querySelector('main')||document.body).appendChild(root); }
+    const legacy = document.querySelector('#subjects-root'); if (legacy && legacy!==root) legacy.style.display='none';
+    return root;
   }
 
   function render(data){
+    ensureClock(); // 放最上面
     const root = ensureRoot();
     const done = loadDone();
     root.innerHTML = '';
 
-    // 分组（按出现顺序）
-    const groups=[], map = new Map();
-    let total=0, checked=0;
-
-    data.forEach((r, i)=>{
-      const s=(r.subject||'').trim(), t=(r.task||'').trim();
+    // 分组
+    const groups = []; const map = new Map();
+    data.forEach(rec=>{
+      const s=(rec.subject||'').trim(), t=(rec.task||'').trim();
       if(!s && !t) return;
-      if(!map.has(s)){ map.set(s,{subject:s, items:[]}); groups.push(map.get(s)); }
-      map.get(s).items.push({ subject:s, task:t, id:idOf(s,t), idx:i });
+      if(!map.has(s)) { map.set(s, { subject:s, items:[] }); groups.push(map.get(s)); }
+      map.get(s).items.push({ ...rec, id:idOf(s,t) });
     });
+
+    let total=0, checked=0;
 
     groups.forEach(g=>{
       const card = document.createElement('section'); card.className='hw-card';
       const title = document.createElement('h2'); title.className='hw-title'; title.textContent = g.subject || '未命名学科';
-      const list = document.createElement('ul'); list.className='hw-list';
+      const list  = document.createElement('ul'); list.className='hw-list';
 
-      g.items.forEach((it)=>{
+      g.items.forEach(it=>{
         total++;
-        const li = document.createElement('li');
-        li.className='hw-item'; li.dataset.idx = String(it.idx);
+        const li = document.createElement('li'); li.className='hw-item'; li.dataset.idx = it.idx;
         const isDone = !!done[it.id]; if (isDone){ li.classList.add('hw-done'); checked++; }
         li.innerHTML = `
           <button class="hw-check" type="button" aria-pressed="${isDone}"></button>
@@ -155,15 +164,25 @@
           li.querySelector('.hw-check').setAttribute('aria-pressed', now ? 'true' : 'false');
           if (now){ done[it.id]=1; checked++; } else { delete done[it.id]; checked--; }
           saveDone(done);
-          // 置底/回原位并带 FLIP 过渡
-          resort(list);
+          // 使用 FLIP 排序：未完成在前；同组按原 idx
+          reorderWithFLIP(list, (a,b)=>{
+            const ad = a.classList.contains('hw-done') ? 1 : 0;
+            const bd = b.classList.contains('hw-done') ? 1 : 0;
+            if (ad !== bd) return ad - bd;
+            return (+a.dataset.idx) - (+b.dataset.idx);
+          });
           updateProgress(total, checked);
         });
         list.appendChild(li);
       });
 
-      // 初始化一次排序（把已完成置底）
-      resort(list);
+      // 初次渲染也整理一次顺序
+      reorderWithFLIP(list, (a,b)=>{
+        const ad = a.classList.contains('hw-done') ? 1 : 0;
+        const bd = b.classList.contains('hw-done') ? 1 : 0;
+        if (ad !== bd) return ad - bd;
+        return (+a.dataset.idx) - (+b.dataset.idx);
+      });
 
       card.appendChild(title); card.appendChild(list);
       root.appendChild(card);
@@ -180,7 +199,9 @@
       render(parseCSV(text));
     }catch(e){
       console.warn('[homework] boot failed:', e);
-      const root = ensureRoot(); root.innerHTML = `<div class="hw-error">加载作业数据失败，请稍后刷新。</div>`;
+      ensureClock();
+      const root = ensureRoot();
+      root.innerHTML = `<div class="hw-error">加载作业数据失败，请稍后刷新。</div>`;
       updateProgress(0,0);
     }
   }
@@ -188,3 +209,4 @@
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot, { once:true });
   else (window.requestIdleCallback||setTimeout)(boot,0);
 })();
+

--- a/styles/base.css
+++ b/styles/base.css
@@ -108,3 +108,51 @@
 }
 #progress-ring .hw-ring-label{ position:absolute; font-weight:700; font-size:18px; }
 /* stylelint-enable no-descending-specificity */
+
+/* —— 时间卡片（与现有卡片风格一致） —— */
+#clock-root { padding: 0 8px; }
+.clock-card {
+  background:#fff; border-radius:16px; padding:12px 16px; margin:12px 12px 2px;
+  box-shadow:0 6px 20px rgba(0,0,0,.08); text-align:center; font-weight:700; color:#1d1d1f;
+}
+
+/* —— Homework namespace（强化选择器，避免被旧样式覆盖） —— */
+#homework-root { padding: 0 8px 110px; }
+#homework-root .hw-card  { background:#fff; border-radius:16px; padding:16px 20px; box-shadow:0 4px 16px rgba(0,0,0,.06); margin:16px 12px; }
+#homework-root .hw-title { margin:0 0 8px; font-size:20px; font-weight:700; color:#1d1d1f; }
+#homework-root .hw-list  { margin:0; padding:0; list-style:none; }
+#homework-root .hw-item  { display:flex; align-items:flex-start; gap:12px; margin:10px 0; will-change:transform; transition:transform 260ms cubic-bezier(.22,.61,.36,1); }
+#homework-root .hw-text  { position:relative; color:#1d1d1f; }
+
+:root{ --hw-size:22px; --hw-done:#22c55e; --hw-border:#d2d2d7; --hw-strike:rgba(0,0,0,.55); }
+#homework-root .hw-check{
+  appearance:none; -webkit-appearance:none; padding:0; margin-top:2px;
+  width:var(--hw-size); height:var(--hw-size); aspect-ratio:1/1;
+  border-radius:999px; border:2px solid var(--hw-border); background:#fff;
+  display:inline-grid; place-items:center; box-sizing:border-box; line-height:0; cursor:pointer;
+  transition:border-color 160ms cubic-bezier(.22,.61,.36,1), background-color 160ms cubic-bezier(.22,.61,.36,1);
+}
+#homework-root .hw-check::after{
+  content:""; width:10px; height:6px; border-left:2px solid #fff; border-bottom:2px solid #fff;
+  transform:rotate(-45deg) scale(0); transform-origin:left bottom; transition:transform 160ms cubic-bezier(.22,.61,.36,1);
+}
+#homework-root .hw-item.hw-done .hw-check{ background:var(--hw-done); border-color:var(--hw-done); }
+#homework-root .hw-item.hw-done .hw-check::after{ transform:rotate(-45deg) scale(1); }
+
+/* —— 删除线动画（提高优先级，防丢失） —— */
+#homework-root .hw-text::after{
+  content:""; position:absolute; left:0; right:0; top:0.9em; height:1px; background:var(--hw-strike);
+  transform:scaleX(0); transform-origin:left; transition:transform 260ms cubic-bezier(.22,.61,.36,1);
+}
+#homework-root .hw-item.hw-done .hw-text{ color:var(--hw-strike); }
+#homework-root .hw-item.hw-done .hw-text::after{ transform:scaleX(1); }
+
+/* —— 甜甜圈示图（兜底样式） —— */
+#progress-ring{ width:96px;height:96px; display:grid; place-items:center; }
+#progress-ring .hw-ring{
+  width:96px;height:96px;border-radius:50%;
+  background:conic-gradient(#e5e7eb 0deg,#e5e7eb 360deg);
+  -webkit-mask:radial-gradient(farthest-side,#0000 68%,#000 70%);
+          mask:radial-gradient(farthest-side,#0000 68%,#000 70%);
+}
+#progress-ring .hw-ring-label{ position:absolute; font-weight:700; font-size:18px; }


### PR DESCRIPTION
## Summary
- add clock widget container to layout
- reinforce homework card styles, strikethrough animation, progress ring
- overhaul homework script for clock card, FLIP reorder, animated donut

## Testing
- `npm run lint`
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68a26c8492548324adaa027c809d4c80