### PR TITLE
fix: streamline homework progress UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>作业预览 · 苹果拟物</title>
-  <link rel="stylesheet" href="/styles/tokens.css" />
-  <link rel="stylesheet" href="/styles/ios-theme.css" />
   <link rel="stylesheet" href="/styles/base.css" />
-  <link rel="stylesheet" href="/css/base.css" />
-  <link rel="stylesheet" href="/css/layout.css" />
   <link rel="stylesheet" href="/css/hw-panel.css" />
   <link rel="stylesheet" href="/css/donut.css" />
 </head>
@@ -17,7 +13,7 @@
     <canvas id="ion-canvas"></canvas>
     <div class="card time-card" aria-live="polite">
       <div class="time" id="time">--:--:--</div>
-      <div class="date" id="date">----</div>
+      <div class="date" id="date"></div>
     </div>
 
     <section id="subjects">
@@ -26,8 +22,8 @@
 
     <figure class="donut" id="progress">
       <svg viewBox="0 0 100 100" aria-hidden="true">
-        <circle cx="50" cy="50" r="45" class="track" />
-        <circle cx="50" cy="50" r="45" class="ring" id="pctBar" />
+        <circle cx="50" cy="50" r="45" class="bg" />
+        <circle cx="50" cy="50" r="45" class="fg" id="pctBar" />
       </svg>
       <figcaption id="pctText" aria-live="polite">0%</figcaption>
     </figure>
@@ -38,7 +34,8 @@
       </div>
     </div>
   </div>
-  <script defer src="scripts/flip.js"></script>
-  <script src="/scripts/homework.js"></script>
+  <script src="/scripts/flip.js"></script>
+  <script type="module" src="/src/app.js"></script>
+  <script type="module" src="/scripts/homework.js"></script>
 </body>
 </html>

--- a/scripts/homework.js
+++ b/scripts/homework.js
@@ -1,196 +1,116 @@
-(() => {
-  if (window.__HW_BOOTED__) return; window.__HW_BOOTED__ = true;
+import { setProgress } from '/src/app.js';
 
-  const CSV_URL = `/data/homework.csv?ts=${Date.now()}`;
-  const LS_KEY  = 'hw:done:v1';
-  let prevPct = 0;
-  const RADIUS = 45;
-  const CIRCUM = 2 * Math.PI * RADIUS;
+const CSV_URL = `/data/homework.csv?ts=${Date.now()}`;
 
-  // —— 工具
-  function byId(id){ return document.getElementById(id); }
-  // eslint-disable-next-line no-unused-vars
-  function ensure(el, tag='div'){ return el || document.createElement(tag); }
-  function animateNumber(el, from, to, ms=380){
-    const t0 = performance.now();
-    const tick = (now)=>{
-      const p = Math.min(1,(now-t0)/ms);
-      const v = Math.round(from + (to-from)*p);
-      el.textContent = `${v}%`;
-      if (p < 1) requestAnimationFrame(tick);
-    };
-    requestAnimationFrame(tick);
+function saveCheckedState(subject, text, checked) {
+  const key = `hw:${subject}:${text}`;
+  try {
+    if (checked) localStorage.setItem(key, '1');
+    else localStorage.removeItem(key);
+  } catch { /* ignore */ }
+}
+
+function getCheckedState(subject, text) {
+  const key = `hw:${subject}:${text}`;
+  try {
+    return localStorage.getItem(key) === '1';
+  } catch {
+    /* ignore */
+    return false;
   }
-  function animateRing(fromPct, toPct, ms=380){
-    const bar = byId('pctBar');
-    if (!bar) return;
-    const t0 = performance.now();
-    const tick = (now)=>{
-      const p = Math.min(1,(now-t0)/ms);
-      const cur = fromPct + (toPct-fromPct)*p;
-      bar.style.strokeDasharray = CIRCUM;
-      bar.style.strokeDashoffset = (1 - cur/100) * CIRCUM;
-      if (p < 1) requestAnimationFrame(tick);
-    };
-    requestAnimationFrame(tick);
+}
+
+function renderTaskItem(text, checked = false) {
+  const li = document.createElement('li');
+  li.className = 'task';
+  const id = 't_' + Math.random().toString(36).slice(2);
+  li.innerHTML = `
+    <label class="task__label" for="${id}">
+      <input id="${id}" class="task__input" type="checkbox" ${checked ? 'checked' : ''} />
+      <span class="task__box" aria-hidden="true"></span>
+      <span class="task__text"></span>
+    </label>`;
+  li.querySelector('.task__text').textContent = text;
+  return li;
+}
+
+function updateProgress() {
+  const all = document.querySelectorAll('.task__input');
+  const checked = document.querySelectorAll('.task__input:checked');
+  const pct = all.length ? Math.round((checked.length / all.length) * 100) : 0;
+  setProgress(pct);
+}
+
+document.addEventListener('change', (e) => {
+  const input = e.target.closest('.task__input');
+  if (!input) return;
+  const label = input.closest('.task__label');
+  if (!label) return;
+  const text = label.querySelector('.task__text')?.textContent || '';
+  const subject = label.closest('.subject-card')?.querySelector('h2')?.textContent || '';
+  saveCheckedState(subject, text, input.checked);
+  updateProgress();
+});
+
+function parseCSV(text) {
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
+  text = text.replace(/\r\n?/g, '\n');
+  const rows = [], row = [];
+  const push = () => { if (row.some((c) => c.trim() !== '')) rows.push(row.splice(0)); };
+  let cur = '', q = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i], nx = text[i + 1];
+    if (ch === '"') { if (q && nx === '"') { cur += '"'; i++; } else q = !q; }
+    else if (ch === ',' && !q) { row.push(cur); cur = ''; }
+    else if (ch === '\n' && !q) { row.push(cur); cur = ''; push(); }
+    else cur += ch;
   }
+  if (cur.length || row.length) { row.push(cur); push(); }
+  if (!rows.length) return [];
+  const header = rows[0].map((h) => h.trim().toLowerCase());
+  const sIdx = header.indexOf('subject'), tIdx = header.indexOf('task');
+  return rows.slice(1).map((r) => ({ subject: (r[sIdx] || '').trim(), task: (r[tIdx] || '').trim() }));
+}
 
-  // —— 存取
-  function idOf(subject, task){
-    const s = `${subject}||${task}`; let h = 2166136261;
-    for (let i=0;i<s.length;i++){ h ^= s.charCodeAt(i); h = (h * 16777619) >>> 0; }
-    return h.toString(36);
-  }
-  function loadDone(){ try{ return JSON.parse(localStorage.getItem(LS_KEY)||'{}'); }catch{ return {}; } }
-  function saveDone(m){ try{ localStorage.setItem(LS_KEY, JSON.stringify(m)); }catch{ /* ignore */ } }
-
-  // —— CSV 两列解析
-  function parseCSV(text){
-    if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1);
-    text = text.replace(/\r\n?/g,'\n');
-    const rows=[], row=[], push=()=>{ if(row.some(c=>c.trim()!=='')) rows.push(row.splice(0)); };
-    let cur='', q=false;
-    for (let i=0;i<text.length;i++){
-      const ch=text[i], nx=text[i+1];
-      if(ch=='"'){ if(q&&nx=='"'){cur+='"'; i++;} else q=!q; }
-      else if(ch==',' && !q){ row.push(cur); cur=''; }
-      else if(ch=='\n' && !q){ row.push(cur); cur=''; push(); }
-      else cur+=ch;
-    }
-    if(cur.length||row.length){ row.push(cur); push(); }
-    if(!rows.length) return [];
-    const header = rows[0].map(h=>h.trim().toLowerCase());
-    const sIdx = header.indexOf('subject'), tIdx = header.indexOf('task');
-    return rows.slice(1).map((r, idx) => ({ subject:(r[sIdx]||'').trim(), task:(r[tIdx]||'').trim(), idx }));
-  }
-
-  // —— 时间卡片
-  function ensureClock(){
-    const timeEl = byId('time');
-    const dateEl = byId('date');
-    if (!timeEl || !dateEl) return;
-    const tick = () => {
-      const d = new Date();
-      timeEl.textContent = `${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}:${String(d.getSeconds()).padStart(2,'0')}`;
-      dateEl.textContent = `${d.getFullYear()}/${d.getMonth()+1}/${d.getDate()}`;
-    };
-    tick();
-    clearInterval(window.__HW_CLOCK_TMR__);
-    window.__HW_CLOCK_TMR__ = setInterval(tick, 1000);
-  }
-  function updateProgress(total, checked){
-    const pct = total ? Math.round(checked/total*100) : 0;
-    const label = byId('pctText');
-    animateNumber(label, prevPct, pct, 380);
-    animateRing(prevPct, pct, 380);
-    prevPct = pct;
-  }
-
-  // —— FLIP 排序：已完成置底，取消回原位（按 idx）
-  function reorderWithFLIP(list, comparator){
-    const children = Array.from(list.children);
-    const first = new Map(children.map(el => [el, el.getBoundingClientRect()]));
-    // 变更 DOM 顺序
-    const sorted = Array.from(children).sort(comparator);
-    sorted.forEach(el => list.appendChild(el));
-    // 计算最后位置并反向位移
-    requestAnimationFrame(()=>{
-      sorted.forEach(el=>{
-        const last = el.getBoundingClientRect();
-        const invX = first.get(el).left - last.left;
-        const invY = first.get(el).top  - last.top;
-        el.style.transform = `translate(${invX}px, ${invY}px)`;
-      });
-      // 下一帧回归->触发过渡
-      requestAnimationFrame(()=> sorted.forEach(el=> el.style.transform = 'translate(0,0)'));
-    });
-  }
-
-  // —— 视图渲染
-  function ensureRoot(){
-    let root = byId('homework-root');
-    if(!root){ root = document.createElement('div'); root.id='homework-root'; (document.querySelector('main')||document.body).appendChild(root); }
-    return root;
-  }
-
-  function render(data){
-    ensureClock(); // 放最上面
-    const root = ensureRoot();
-    const done = loadDone();
-    root.innerHTML = '';
-
-    // 分组
-    const groups = []; const map = new Map();
-    data.forEach(rec=>{
-      const s=(rec.subject||'').trim(), t=(rec.task||'').trim();
-      if(!s && !t) return;
-      if(!map.has(s)) { map.set(s, { subject:s, items:[] }); groups.push(map.get(s)); }
-      map.get(s).items.push({ ...rec, id:idOf(s,t) });
-    });
-
-    let total=0, checked=0;
-
-    groups.forEach(g=>{
-      const card = document.createElement('section'); card.className='hw-card';
-      const title = document.createElement('h2'); title.className='hw-title'; title.textContent = g.subject || '未命名学科';
-      const list  = document.createElement('ul'); list.className='hw-list';
-
-      g.items.forEach(it=>{
-        total++;
-        const li = document.createElement('li'); li.className='hw-item'; li.dataset.idx = it.idx;
-        const isDone = !!done[it.id]; if (isDone){ li.classList.add('hw-done'); checked++; }
-        li.innerHTML = `
-          <button class="hw-check" type="button" aria-pressed="${isDone}"></button>
-          <div class="hw-text">${it.task || ''}</div>
-        `;
-        li.querySelector('.hw-check').addEventListener('click', ()=>{
-          const now = li.classList.toggle('hw-done');
-          li.querySelector('.hw-check').setAttribute('aria-pressed', now ? 'true' : 'false');
-          if (now){ done[it.id]=1; checked++; } else { delete done[it.id]; checked--; }
-          saveDone(done);
-          // 使用 FLIP 排序：未完成在前；同组按原 idx
-          reorderWithFLIP(list, (a,b)=>{
-            const ad = a.classList.contains('hw-done') ? 1 : 0;
-            const bd = b.classList.contains('hw-done') ? 1 : 0;
-            if (ad !== bd) return ad - bd;
-            return (+a.dataset.idx) - (+b.dataset.idx);
-          });
-          updateProgress(total, checked);
-        });
-        list.appendChild(li);
-      });
-
-      // 初次渲染也整理一次顺序
-      reorderWithFLIP(list, (a,b)=>{
-        const ad = a.classList.contains('hw-done') ? 1 : 0;
-        const bd = b.classList.contains('hw-done') ? 1 : 0;
-        if (ad !== bd) return ad - bd;
-        return (+a.dataset.idx) - (+b.dataset.idx);
-      });
-
-      card.appendChild(title); card.appendChild(list);
+function render(data) {
+  const root = document.getElementById('homework-root');
+  if (!root) return;
+  root.innerHTML = '';
+  const map = new Map();
+  data.forEach(({ subject, task }) => {
+    if (!subject && !task) return;
+    let ul = map.get(subject);
+    if (!ul) {
+      const card = document.createElement('div');
+      card.className = 'subject-card';
+      const h2 = document.createElement('h2');
+      h2.textContent = subject || '';
+      const list = document.createElement('ul');
+      card.appendChild(h2);
+      card.appendChild(list);
       root.appendChild(card);
-    });
-
-    updateProgress(total, checked);
-  }
-
-  async function boot(){
-    try{
-      const res = await fetch(CSV_URL, { cache:'no-store' });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const text = await res.text();
-      render(parseCSV(text));
-    }catch(e){
-      console.warn('[homework] boot failed:', e);
-      ensureClock();
-      const root = ensureRoot();
-      root.innerHTML = `<div class="hw-error">加载作业数据失败，请稍后刷新。</div>`;
-      updateProgress(0,0);
+      map.set(subject, list);
+      ul = list;
     }
-  }
+    ul.appendChild(renderTaskItem(task, getCheckedState(subject, task)));
+  });
+  updateProgress();
+}
 
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot, { once:true });
-  else (window.requestIdleCallback||setTimeout)(boot,0);
-})();
+async function boot() {
+  try {
+    const res = await fetch(CSV_URL, { cache: 'no-store' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const text = await res.text();
+    render(parseCSV(text));
+  } catch (e) {
+    console.warn('[homework] load failed:', e);
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', boot, { once: true });
+} else {
+  boot();
+}
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,64 +1,21 @@
-import './clock.js';
-import { initHwPanel } from './hw-panel/index.js';
-import { initDonut } from './donut/index.js';
+const $time = document.getElementById('time');
+const $date = document.getElementById('date');
+function pad(n){return String(n).padStart(2,'0');}
+function tick(){
+  const d = new Date();
+  $time && ($time.textContent = `${d.getFullYear()}/${d.getMonth()+1}/${d.getDate()} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`);
+  if ($date) $date.textContent = '';
+}
+setInterval(tick,1000); tick();
 
-const app = document.getElementById('app');
-const ionCanvas = document.getElementById('ion-canvas');
-const subjectsEl = document.getElementById('subjects');
-const { update } = initDonut({
-  ring: document.getElementById('ring'),
-  text: document.getElementById('pctText'),
-  donut: document.querySelector('.donut')
-});
-
-function celebrate() {
-  if (document.body.classList.contains('disintegrate')) return;
-  document.body.classList.add('disintegrate');
-  const rect = app.getBoundingClientRect();
-  const cw = ionCanvas.width = rect.width * (window.devicePixelRatio || 1);
-  const ch = ionCanvas.height = rect.height * (window.devicePixelRatio || 1);
-  const ctx = ionCanvas.getContext('2d');
-  ionCanvas.style.display = 'block';
-  ionCanvas.style.position = 'absolute';
-  ionCanvas.style.left = '0';
-  ionCanvas.style.top = '0';
-  const particles = [];
-  const N = 320;
-  for (let i = 0; i < N; i++) {
-    particles.push({
-      x: Math.random() * cw,
-      y: Math.random() * ch,
-      vx: (Math.random() - 0.5) * 2.2,
-      vy: -Math.random() * 2 - .5,
-      r: Math.random() * 2 + .6,
-      life: 1,
-    });
-  }
-  function step() {
-    ctx.clearRect(0, 0, cw, ch);
-    let alive = 0;
-    for (const p of particles) {
-      p.x += p.vx * 3; p.y += p.vy * 3; p.vy += 0.03; p.life -= 0.008;
-      if (p.life > 0) {
-        alive++;
-        ctx.globalAlpha = Math.max(0, p.life);
-        ctx.fillStyle = '#9ad6a8';
-        ctx.beginPath(); ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2); ctx.fill();
-      }
-    }
-    if (alive > 0) {
-      requestAnimationFrame(step);
-    } else {
-      app.classList.add('show-done');
-    }
-  }
-  requestAnimationFrame(step);
+const donut = document.getElementById('progress');
+const pctText = donut?.querySelector('#pctText');
+const pctBar  = donut?.querySelector('#pctBar');
+const C = 2 * Math.PI * 45; // r=45
+if (pctBar) pctBar.style.strokeDasharray = String(C);
+export function setProgress(p){
+  const pct = Math.max(0, Math.min(100, p|0));
+  if (pctText) pctText.textContent = pct + '%';
+  if (pctBar) pctBar.style.strokeDashoffset = String(C * (1 - pct/100));
 }
 
-initHwPanel({
-  mount: subjectsEl,
-  onProgress(pct) {
-    update(pct);
-    if (pct === 100) celebrate();
-  }
-});

--- a/styles/base.css
+++ b/styles/base.css
@@ -108,6 +108,19 @@
 }
 #progress-ring .hw-ring-label{ position:absolute; font-weight:700; font-size:18px; }
 
+/* —— 取消内层滚动，仅保留页面滚动 —— */
+#subjects, .panel__body { max-height: none; overflow: visible; -webkit-overflow-scrolling: auto; }
+
+/* —— 任务项可点区域（label 包裹）—— */
+.task { list-style: none; }
+.task__label { display: flex; align-items: center; gap: .75rem; cursor: pointer; user-select: none; }
+.task__input { position: absolute; opacity: 0; width: 0; height: 0; }
+.task__box { width: 22px; height: 22px; border: 2px solid var(--border, #d2d2d7); border-radius: 50%; display: inline-block; position: relative; transition: border-color .2s, background .2s; flex: 0 0 22px; }
+.task__input:checked + .task__box { background: var(--checked-color, #28a745); border-color: var(--checked-color, #28a745); }
+.task__input:checked + .task__box::after { content: ""; position: absolute; left: 6px; top: 2px; width: 6px; height: 12px; border: solid #fff; border-width: 0 2px 2px 0; transform: rotate(45deg); }
+.task__text { color: var(--text, #1d1d1f); transition: color .2s, text-decoration-color .2s; }
+.task__input:checked + .task__box + .task__text { color: var(--muted-text, #6e6e73); text-decoration: line-through; text-decoration-thickness: 2px; text-decoration-color: rgba(0,0,0,.35); }
+
 /* —— 时间卡片 —— */
 .time-card{
   background:#fff; border-radius:16px; padding:12px 16px; margin:12px auto 2px;
@@ -171,3 +184,15 @@
           mask:radial-gradient(farthest-side,#0000 68%,#000 70%);
 }
 #progress-ring .hw-ring-label{ position:absolute; font-weight:700; font-size:18px; }
+/* —— 取消内层滚动，仅保留页面滚动 —— */
+#subjects, .panel__body { max-height: none; overflow: visible; -webkit-overflow-scrolling: auto; }
+
+/* —— 任务项可点区域（label 包裹）—— */
+.task { list-style: none; }
+.task__label { display: flex; align-items: center; gap: .75rem; cursor: pointer; user-select: none; }
+.task__input { position: absolute; opacity: 0; width: 0; height: 0; }
+.task__box { width: 22px; height: 22px; border: 2px solid var(--border, #d2d2d7); border-radius: 50%; display: inline-block; position: relative; transition: border-color .2s, background .2s; flex: 0 0 22px; }
+.task__input:checked + .task__box { background: var(--checked-color, #28a745); border-color: var(--checked-color, #28a745); }
+.task__input:checked + .task__box::after { content: ""; position: absolute; left: 6px; top: 2px; width: 6px; height: 12px; border: solid #fff; border-width: 0 2px 2px 0; transform: rotate(45deg); }
+.task__text { color: var(--text, #1d1d1f); transition: color .2s, text-decoration-color .2s; }
+.task__input:checked + .task__box + .task__text { color: var(--muted-text, #6e6e73); text-decoration: line-through; text-decoration-thickness: 2px; text-decoration-color: rgba(0,0,0,.35); }


### PR DESCRIPTION
## Summary
- refactor homework renderer to use label-based tasks with global progress
- remove inner scroll and duplicate donut/time elements
- update time and progress scripts for single instance updates

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a41f4ddf74832498414fba0a59abc0