### PR TITLE
refactor(hw): extract homework data into its own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ src/            # 源码：入口、作业板块、甜甜圈、工具等
 ```
 
 ## 二次开发
+作业数据位于 `src/hw-panel/data.js`，可直接编辑以调整内容。
 修改 `src/hw-panel/*` 可独立定制作业 UI 与交互；入口逻辑位于 `src/app.js`。
 使用 `npm run lint` 可运行 ESLint 与 Stylelint。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,8 +5,9 @@ index.html
   └─ src/app.js 入口
       ├─ src/clock.js            # 刷新时刻渲染
       ├─ src/donut/              # 甜甜圈进度动画
-      └─ src/hw-panel/           # 作业板块（状态/渲染/排序）
-          ├─ state.js            # 数据与进度计算
+      └─ src/hw-panel/           # 作业板块（数据/状态/渲染/排序）
+          ├─ data.js             # 默认作业数据
+          ├─ state.js            # 状态与进度计算
           ├─ render.js           # DOM 渲染
           ├─ sort.js             # 稳定排序
           └─ index.js            # 对外 API
@@ -15,7 +16,7 @@ index.html
 ```
 
 ## 数据流
-1. `state.js` 保存学科与任务勾选状态，并提供 `selectProgress()` 计算完成度。
+1. `data.js` 提供初始作业列表；`state.js` 保存学科与任务勾选状态，并提供 `selectProgress()` 计算完成度。
 2. `index.js` 监听勾选变化，更新状态并通过 `onProgress(percent)` 回调通知外层。
 3. `app.js` 将进度传递给 `donut` 模块并在 100% 时触发庆祝动画。
 

--- a/src/hw-panel/data.js
+++ b/src/hw-panel/data.js
@@ -1,0 +1,11 @@
+export const subjects = [
+  { id: 's1', name: '语文', tasks: ['背诵《木兰诗》前半段', '完成练习册 P12-15 选择题'] },
+  { id: 's2', name: '数学', tasks: ['函数单调性 2-12 题', '错题本整理 10 分钟'] },
+  { id: 's3', name: '英语', tasks: ['背词 Unit 3 A-B', '完成 Workbook P20-23'] },
+  { id: 's4', name: '物理', tasks: ['受力分析 3 道题', '预习 杠杆与力矩'] },
+  { id: 's5', name: '化学', tasks: ['元素周期表默写', '完成配平 5 题'] },
+  { id: 's6', name: '生物', tasks: ['细胞结构速记 15 分钟'] },
+  { id: 's7', name: '历史', tasks: ['明清时期复习提纲'] },
+  { id: 's8', name: '政治', tasks: ['核心价值观要点背诵'] },
+  { id: 's9', name: '地理', tasks: ['世界气候类型速查表'] }
+];

--- a/src/hw-panel/state.js
+++ b/src/hw-panel/state.js
@@ -1,15 +1,7 @@
+import { subjects } from './data.js';
+
 let seq = 0;
-const initial = [
-  { id: 's1', name: '语文', tasks: ['背诵《木兰诗》前半段', '完成练习册 P12-15 选择题'] },
-  { id: 's2', name: '数学', tasks: ['函数单调性 2-12 题', '错题本整理 10 分钟'] },
-  { id: 's3', name: '英语', tasks: ['背词 Unit 3 A-B', '完成 Workbook P20-23'] },
-  { id: 's4', name: '物理', tasks: ['受力分析 3 道题', '预习 杠杆与力矩'] },
-  { id: 's5', name: '化学', tasks: ['元素周期表默写', '完成配平 5 题'] },
-  { id: 's6', name: '生物', tasks: ['细胞结构速记 15 分钟'] },
-  { id: 's7', name: '历史', tasks: ['明清时期复习提纲'] },
-  { id: 's8', name: '政治', tasks: ['核心价值观要点背诵'] },
-  { id: 's9', name: '地理', tasks: ['世界气候类型速查表'] }
-].map((s, i) => ({
+const initial = subjects.map((s, i) => ({
   id: s.id,
   seq: i,
   name: s.name,


### PR DESCRIPTION
## Summary
- move homework list into `src/hw-panel/data.js` for easier editing
- load subjects from new data file in `state.js`
- document data file in README and architecture docs

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a54988570083248c9f48c8ab41a8b7