### PR TITLE
Fix subject text visibility on browsers without gradient clip

### DIFF
--- a/css/hw-panel.css
+++ b/css/hw-panel.css
@@ -29,13 +29,22 @@
 }
 .text{
   position:relative; font-size:16px; letter-spacing:.2px; line-height:1.4;
-  color:transparent; -webkit-background-clip:text; background-clip:text;
-  background-image: linear-gradient(90deg,
-    rgba(0,0,0,.55) 0%,
-    rgba(0,0,0,.55) calc((var(--p)*100% - 2%)),
-    rgba(0,0,0,1) calc(var(--p)*100%),
-    rgba(0,0,0,1) 100%
-  );
+  color:var(--label);
+}
+
+@supports ((-webkit-background-clip: text) or (background-clip: text)) {
+  .text{
+    color:transparent;
+    -webkit-text-fill-color: transparent;
+    -webkit-background-clip:text;
+    background-clip:text;
+    background-image: linear-gradient(90deg,
+      rgba(0,0,0,.55) 0%,
+      rgba(0,0,0,.55) calc((var(--p)*100% - 2%)),
+      rgba(0,0,0,1) calc(var(--p)*100%),
+      rgba(0,0,0,1) 100%
+    );
+  }
 }
 .text::after{
   content:""; position:absolute; left:0; right:0; top:50%; height:2px; border-radius:2px; background:var(--strike);


### PR DESCRIPTION
## Summary
- provide a plain color fallback for task text so it stays readable when gradient text clipping is unavailable
- scope the gradient styling to supporting browsers and add `-webkit-text-fill-color` for Safari

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3e0e94d28832489f1d66d70e99b2f