### PR TITLE
Ensure progress donut renders above panel blur

### DIFF
--- a/assets/styles/base/layout.css
+++ b/assets/styles/base/layout.css
@@ -11,10 +11,77 @@
   font-weight:700; text-align:center;
 }
 .card.panel{ background:var(--card); border-radius:var(--radius); box-shadow:var(--shadow);
-        display:flex; flex-direction:column; min-height:0; overflow:hidden; }
-.panel__body{ flex:1; min-height:0; overflow-y:auto; scrollbar-gutter:stable; padding:var(--gap); }
+        display:flex; flex-direction:column; min-height:0; overflow:hidden; position:relative; }
+.panel__body{ flex:1; min-height:0; overflow-y:auto; scrollbar-gutter:stable; padding:var(--gap);
+        padding-bottom:calc(var(--gap) + 6rem); position:relative; }
 @supports not (scrollbar-gutter:stable){
   .panel__body{ overflow-y:scroll; padding-right:calc(var(--gap) + 8px); }
+}
+.panel__blur{
+  --blur-height: 6rem;
+  --blur-strength: 18px;
+  position:absolute;
+  left:0;
+  right:0;
+  bottom:0;
+  height:var(--blur-height);
+  pointer-events:none;
+  backdrop-filter:blur(var(--blur-strength));
+  -webkit-backdrop-filter:blur(var(--blur-strength));
+  background:linear-gradient(180deg,
+    rgba(255,255,255,0) 0%,
+    rgba(245,245,247,0.65) 35%,
+    rgba(245,245,247,0.94) 100%);
+  mask-image:linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.2) 28%, rgba(0,0,0,0.65) 54%, rgba(0,0,0,1) 100%);
+  -webkit-mask-image:linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.2) 28%, rgba(0,0,0,0.65) 54%, rgba(0,0,0,1) 100%);
+  opacity:0;
+  visibility:hidden;
+  transition:opacity var(--dur-med) var(--ease-standard), visibility var(--dur-med) var(--ease-standard);
+  will-change:opacity;
+  z-index:1;
+}
+
+.panel__blur::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(circle at center, rgba(255,255,255,0.35), rgba(255,255,255,0) 65%);
+  opacity:0.65;
+}
+
+.panel__blur[data-state="visible"]{
+  opacity:calc(var(--blur-progress, 1));
+  visibility:visible;
+}
+
+.panel__blur[data-state="visible"]::before{
+  opacity:calc(0.45 + 0.2 * var(--blur-progress, 1));
+}
+
+@supports not ((backdrop-filter:blur(1px)) or (-webkit-backdrop-filter:blur(1px))){
+  .panel__blur{
+    background:linear-gradient(180deg,
+      rgba(255,255,255,0) 0%,
+      rgba(255,255,255,0.6) 36%,
+      rgba(245,245,247,0.96) 100%);
+  }
+}
+
+@media (prefers-color-scheme: dark){
+  .panel__blur{
+    background:linear-gradient(180deg,
+      rgba(0,0,0,0) 0%,
+      rgba(20,20,22,0.55) 34%,
+      rgba(20,20,22,0.9) 100%);
+  }
+  @supports ((backdrop-filter:blur(1px)) or (-webkit-backdrop-filter:blur(1px))){
+    .panel__blur{
+      background:linear-gradient(180deg,
+        rgba(0,0,0,0) 0%,
+        rgba(20,20,22,0.55) 34%,
+        rgba(20,20,22,0.9) 100%);
+    }
+  }
 }
 #ion-canvas{ display:none; position:absolute; top:0; left:0; pointer-events:none; width:100%; height:100%; }
 .modal.done-screen{ position:absolute; inset:0; display:none; align-items:center; justify-content:center; text-align:center; padding:24px; }

--- a/assets/styles/components/donut.css
+++ b/assets/styles/components/donut.css
@@ -1,6 +1,6 @@
 .donut{ position:fixed; left:50%; transform:translateX(-50%);
         bottom:calc(16px + env(safe-area-inset-bottom)); width:92px; height:92px;
-        display:grid; place-items:center; }
+        display:grid; place-items:center; z-index:10; }
 .donut svg, .donut figcaption{ grid-area:1/1; }
 .donut circle{ fill:none; stroke-width:12; }
 .donut .track{ stroke:#e5e5ea; }

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     </div>
     <div class="card panel">
       <div class="panel__body" id="subjects"></div>
+      <div class="panel__blur" aria-hidden="true"></div>
     </div>
     <figure class="donut" role="progressbar" aria-label="整体完成度" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
       <svg viewBox="0 0 92 92">


### PR DESCRIPTION
## Summary
- elevate the progress donut's stacking order so it is not obscured by the homework panel blur overlay

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4ecc088a08324a6982d2c87748654