### PR TITLE
Fix donut ring transition to prevent theme flicker

### DIFF
--- a/assets/styles/components/donut.css
+++ b/assets/styles/components/donut.css
@@ -1,11 +1,13 @@
 .donut{ position:fixed; left:50%; transform:translateX(-50%);
         bottom:calc(16px + env(safe-area-inset-bottom)); width:92px; height:92px;
-        display:grid; place-items:center; z-index:10; }
+        display:grid; place-items:center; z-index:10; contain:paint; isolation:isolate; }
 .donut svg, .donut figcaption{ grid-area:1/1; }
 .donut circle{ fill:none; stroke-width:12; }
 .donut .track{ stroke:#e5e5ea; }
 .donut .ring{ stroke:var(--accent); transform-origin:50% 50%; transform:rotate(-90deg);
-               transition: transform var(--dur-med) var(--ease-standard), opacity var(--dur-med) var(--ease-standard); }
+               transition: stroke-dashoffset var(--donut-dur) var(--ease-standard),
+                           stroke var(--dur-med) var(--ease-standard);
+               will-change:stroke-dashoffset; }
 @media (prefers-reduced-motion: reduce){
   .donut .ring{ transition:none; }
 }


### PR DESCRIPTION
## Summary
- limit the donut ring animation to stroke changes to avoid transform/opacity jumps
- add paint containment to the donut container to reduce compositing during theme switches

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e50e5027908324b0877e260a41f812